### PR TITLE
fix/remove-datasource-external-link

### DIFF
--- a/features/ati/AtiManuscript/DatasourceModal/index.tsx
+++ b/features/ati/AtiManuscript/DatasourceModal/index.tsx
@@ -71,9 +71,7 @@ const DatasourceModal: FC<DatasourceModalProps> = ({
         )}
         {datasources.map(({ id, name, uri }) => (
           <div key={id} className={styles.datasource}>
-            <Link target="_blank" rel="noopener noreferrer" size="lg" href={uri}>
-              {name}
-            </Link>
+            <p>{name}</p>
             <CopyToClipboard key={id} text={uri}>
               <CopyButton
                 feedback="Copied!"


### PR DESCRIPTION
Resolves #42 

Don't link the data source back to QDR, by changing the element from `Link` to `p`.