### PR TITLE
fix/orphaned-annotations

### DIFF
--- a/features/ati/AtiManuscript/IngestPdf/index.tsx
+++ b/features/ati/AtiManuscript/IngestPdf/index.tsx
@@ -42,6 +42,7 @@ const IngestPdf: FC<IngestPdfProps> = ({ pdf }) => {
               width={size.width as number}
               renderMode="canvas"
               renderAnnotationLayer={false}
+              loading=""
             />
           ))}
         </Document>

--- a/features/components/Layout/index.tsx
+++ b/features/components/Layout/index.tsx
@@ -25,8 +25,8 @@ const Layout: FC<LayoutProps> = ({ title, children, isLoggedIn, isFullWidth, has
       const hClient = document.createElement("script")
       hClient.src = "https://hypothes.is/embed.js"
       hClient.async = true
-      document.body.appendChild(hClientConfig)
-      document.body.appendChild(hClient)
+      document.head.appendChild(hClientConfig)
+      document.head.appendChild(hClient)
     }
   }, [hasPdf])
 

--- a/features/components/Layout/index.tsx
+++ b/features/components/Layout/index.tsx
@@ -1,7 +1,7 @@
-import { ReactNode, FC } from "react"
+import { ReactNode, FC, useEffect } from "react"
 
-import Head from "next/head"
 import DOMPurify from "isomorphic-dompurify"
+import Head from "next/head"
 
 import AppBar from "../AppBar"
 
@@ -16,6 +16,20 @@ interface LayoutProps {
 }
 
 const Layout: FC<LayoutProps> = ({ title, children, isLoggedIn, isFullWidth, hasPdf }) => {
+  useEffect(() => {
+    if (hasPdf) {
+      const hClientConfig = document.createElement("script")
+      hClientConfig.type = "application/json"
+      hClientConfig.className = "js-hypothesis-config"
+      hClientConfig.innerHTML = DOMPurify.sanitize(JSON.stringify({ openSidebar: true }))
+      const hClient = document.createElement("script")
+      hClient.src = "https://hypothes.is/embed.js"
+      hClient.async = true
+      document.body.appendChild(hClientConfig)
+      document.body.appendChild(hClient)
+    }
+  }, [hasPdf])
+
   return (
     <>
       <Head>
@@ -23,18 +37,6 @@ const Layout: FC<LayoutProps> = ({ title, children, isLoggedIn, isFullWidth, has
         <meta charSet="utf-8" />
         <meta name="viewport" content="initial-scale=1.0, width=device-width" />
       </Head>
-      {hasPdf && (
-        <>
-          <script
-            type="application/json"
-            className="js-hypothesis-config"
-            dangerouslySetInnerHTML={{
-              __html: DOMPurify.sanitize(JSON.stringify({ openSidebar: true })),
-            }}
-          ></script>
-          <script async src="https://hypothes.is/embed.js"></script>
-        </>
-      )}
       <div className={styles.container}>
         <AppBar isLoggedIn={isLoggedIn} />
         <main className={`${styles.main} ${isFullWidth ? styles.fullMaxWidth : styles.maxWidth}`}>


### PR DESCRIPTION
Resolves #45 

- Attach the hypothesis client (annotation sidebar) after the page has loaded
- Remove `loading page` default message