### PR TITLE
Upgrade alert level of login to hypothesis banner to `warning`

### DIFF
--- a/features/auth/HypothesisLoginNotificaton/index.tsx
+++ b/features/auth/HypothesisLoginNotificaton/index.tsx
@@ -24,9 +24,9 @@ const HypothesisLoginNotification: FC = () => {
       <InlineNotification
         hideCloseButton
         lowContrast
-        kind="info"
-        statusIconDescription="info"
-        title="Log in to Hypothes.is to see your annotations in the Annotation sidebar."
+        kind="warning-alt"
+        statusIconDescription="warning"
+        title="Log in to Hypothes.is to see your annotations in the Annotation sidebar on the right."
         actions={<NotificationActionButton onClick={onClickOK}>OK</NotificationActionButton>}
       />
     )

--- a/features/auth/HypothesisLoginNotificaton/index.tsx
+++ b/features/auth/HypothesisLoginNotificaton/index.tsx
@@ -26,7 +26,7 @@ const HypothesisLoginNotification: FC = () => {
         lowContrast
         kind="warning-alt"
         statusIconDescription="warning"
-        title="Log in to Hypothes.is to see your annotations in the Annotation sidebar on the right."
+        title="Log in to Hypothes.is in the Annotation sidebar to the right to see your annotations."
         actions={<NotificationActionButton onClick={onClickOK}>OK</NotificationActionButton>}
       />
     )


### PR DESCRIPTION
Resolves #52 

- Upgrade the banner to have a `warning` level
- Reference that `log in` is found in the right side
