### PR TITLE
Improve new ATI form

### DIFF
--- a/features/ati/NewAtiProjectForm/NewAtiProjectForm.module.css
+++ b/features/ati/NewAtiProjectForm/NewAtiProjectForm.module.css
@@ -1,12 +1,8 @@
 .searchBox {
   display: grid;
-  grid-template-columns: 1fr 0.15fr;
+  grid-template-columns: 1fr auto;
   align-items: center;
-  column-gap: 8px;
-}
-/*More datasets button*/
-.moreDatasets {
-  padding: 4px;
+  column-gap: 1rem;
 }
 
 /*Separate the title and loader*/

--- a/features/ati/NewAtiProjectForm/index.tsx
+++ b/features/ati/NewAtiProjectForm/index.tsx
@@ -10,7 +10,7 @@ import React, {
 
 import FormData from "form-data"
 import axios from "axios"
-import { Add16 } from "@carbon/icons-react"
+import { Add16, OverflowMenuVertical24 } from "@carbon/icons-react"
 import {
   Button,
   Form,
@@ -18,8 +18,6 @@ import {
   InlineNotification,
   ComboBox,
   InlineLoading,
-  OverflowMenu,
-  OverflowMenuItem,
 } from "carbon-components-react"
 import { debounce } from "lodash"
 import { useRouter } from "next/router"
@@ -201,6 +199,26 @@ const NewAtiProjectForm: FC<NewAtiProjectFormProps> = ({
               />
             </div>
           )}
+          <div className={formStyles.item}>
+            <p className="bx--label">
+              Don&apos;t have a <abbr>QDR</abbr> data project?
+            </p>
+            <div>
+              <Button
+                kind="ghost"
+                size="sm"
+                as="a"
+                href={`${serverUrl}/dataset.xhtml?ownerId=1`}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Create new
+              </Button>
+              <Button kind="ghost" size="sm" onClick={() => router.reload()}>
+                Refresh page
+              </Button>
+            </div>
+          </div>
           <div className={`${formStyles.item} ${styles.searchBox}`}>
             <ComboBox
               id="dataset-search"
@@ -237,21 +255,19 @@ const NewAtiProjectForm: FC<NewAtiProjectFormProps> = ({
               onInput={memoizedHandleSearch}
               onChange={onSelectDataset}
             />
-            <div>
-              <OverflowMenu flipped iconDescription="More options" size="lg">
-                {hasMoreDatasets(state) && (
-                  <OverflowMenuItem requireTitle itemText={`Show more`} onClick={onShowMore} />
-                )}
-                <OverflowMenuItem
-                  href={`${serverUrl}/dataset.xhtml?ownerId=1`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  hasDivider
-                  requireTitle
-                  itemText="Create new"
-                />
-              </OverflowMenu>
-            </div>
+            {hasMoreDatasets(state) && (
+              <Button
+                hasIconOnly
+                kind="tertiary"
+                size="md"
+                iconDescription="More data projects"
+                tooltipPosition="bottom"
+                tooltipAlignment="end"
+                onClick={onShowMore}
+              >
+                <OverflowMenuVertical24 />
+              </Button>
+            )}
           </div>
           <div className={formStyles.item}>
             <FileUploader

--- a/styles/Form.module.css
+++ b/styles/Form.module.css
@@ -4,17 +4,17 @@
 }
 
 .title {
-  margin-bottom: 4px;
+  margin-bottom: 0.5rem;
 }
 
 .desc {
-  margin-bottom: 32px;
+  margin-bottom: 2.5rem;
 }
 
 .item {
-  margin-bottom: 24px;
+  margin-bottom: 2rem;
 }
 
 .submitBtn {
-  margin-top: 32px;
+  margin-top: 1rem;
 }


### PR DESCRIPTION
Resolves #54 

- Refactor `creat new` QDR data project into the form (out of the overflow menu) to make it more visible
- Add a refresh page button so that new QDR data projects are shown in the list of options
- Make the 3 vertical dots more prominent by upgrading it to a `tertiary` button from `ghost` button