### PR TITLE
fix/add-back-hypothesis-login-link

### DIFF
--- a/features/auth/LoginForm/index.tsx
+++ b/features/auth/LoginForm/index.tsx
@@ -107,7 +107,16 @@ const LoginForm: FC<LoginFormProps> = ({
             }
             helperText={
               <div>
-                Get your{" "}
+                <Link
+                  size="sm"
+                  href="https://hypothes.is/login"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Login to Hypothes.is
+                </Link>
+                {", "}
+                then get your{" "}
                 <Link
                   size="sm"
                   href="https://hypothes.is/account/developer"


### PR DESCRIPTION
Add back the Hypothesis login link to the login form.