### PR TITLE
fix/improve-api-token-states

### DIFF
--- a/features/auth/constants.ts
+++ b/features/auth/constants.ts
@@ -1,4 +1,4 @@
-export const LOGIN_ID = "login-id"
+export const LOGIN_ID = "credentials"
 
 export const INVALID_DATAVERSE_API_TOKEN = "The QDR API token is invalid."
 

--- a/hooks/useCredential/index.ts
+++ b/hooks/useCredential/index.ts
@@ -1,0 +1,51 @@
+import { useReducer } from "react"
+
+export enum CredentialActionType {
+  UPDATE,
+  VALIDATE,
+}
+
+export type ICredentialAction =
+  | { type: CredentialActionType.UPDATE; payload: string }
+  | { type: CredentialActionType.VALIDATE; payload: { isInvalid: boolean; invalidText: string } }
+
+interface ICredentialState {
+  credential: string
+  isInvalid: boolean
+  invalidText: string
+}
+
+export function credentialReducer(
+  state: ICredentialState,
+  action: ICredentialAction
+): ICredentialState {
+  switch (action.type) {
+    case CredentialActionType.UPDATE: {
+      return {
+        ...state,
+        credential: action.payload,
+      }
+    }
+    case CredentialActionType.VALIDATE: {
+      return {
+        ...state,
+        isInvalid: action.payload.isInvalid,
+        invalidText: action.payload.invalidText,
+      }
+    }
+  }
+}
+
+export const initialCredentialState: ICredentialState = {
+  credential: "",
+  isInvalid: false,
+  invalidText: "",
+}
+
+export default function useCredential(initialCredentialState: ICredentialState): {
+  state: ICredentialState
+  dispatch: React.Dispatch<ICredentialAction>
+} {
+  const [state, dispatch] = useReducer(credentialReducer, initialCredentialState)
+  return { state, dispatch }
+}

--- a/hooks/useCredential/test/credentialReducer.test.ts
+++ b/hooks/useCredential/test/credentialReducer.test.ts
@@ -1,0 +1,28 @@
+import { CredentialActionType, initialCredentialState, credentialReducer } from ".."
+
+describe("credentialReducer", () => {
+  test("handles update", () => {
+    expect(
+      credentialReducer(initialCredentialState, {
+        type: CredentialActionType.UPDATE,
+        payload: "test",
+      })
+    ).toEqual({
+      ...initialCredentialState,
+      credential: "test",
+    })
+  })
+
+  test("handles validate", () => {
+    expect(
+      credentialReducer(initialCredentialState, {
+        type: CredentialActionType.VALIDATE,
+        payload: { isInvalid: true, invalidText: "test" },
+      })
+    ).toEqual({
+      ...initialCredentialState,
+      isInvalid: true,
+      invalidText: "test",
+    })
+  })
+})


### PR DESCRIPTION
- Refactor React local state for apiToken, isInvalid, invalidText into a reusable React hook `useCredential` so that it can be used for the QDR API token and Hypothesis token
- Return JSON for login error, for a better error message