### PR TITLE
fix/clip-long-datasource-names

### DIFF
--- a/features/ati/AtiManuscript/DatasourceModal/Datasource.module.css
+++ b/features/ati/AtiManuscript/DatasourceModal/Datasource.module.css
@@ -1,0 +1,5 @@
+.datasource {
+  text-overflow: clip;
+  overflow: hidden;
+  white-space: nowrap;
+}

--- a/features/ati/AtiManuscript/DatasourceModal/Datasource.tsx
+++ b/features/ati/AtiManuscript/DatasourceModal/Datasource.tsx
@@ -18,7 +18,7 @@ const Datasource: FC<DatasourceProps> = ({ name }) => {
         setRequireTitle(true)
       }
     }
-  }, [name])
+  }, [])
 
   return (
     <p ref={ref} title={requireTitle ? name : undefined} className={styles.datasource}>

--- a/features/ati/AtiManuscript/DatasourceModal/Datasource.tsx
+++ b/features/ati/AtiManuscript/DatasourceModal/Datasource.tsx
@@ -1,0 +1,30 @@
+import { FC, useRef, useState, useEffect } from "react"
+
+import styles from "./Datasource.module.css"
+
+interface DatasourceProps {
+  name: string
+}
+
+const Datasource: FC<DatasourceProps> = ({ name }) => {
+  const ref = useRef<HTMLParagraphElement>(null)
+  const [requireTitle, setRequireTitle] = useState(false)
+
+  useEffect(() => {
+    if (ref.current) {
+      const element = ref.current
+      if (element.scrollWidth > element.clientWidth) {
+        // name is too long
+        setRequireTitle(true)
+      }
+    }
+  }, [name])
+
+  return (
+    <p ref={ref} title={requireTitle ? name : undefined} className={styles.datasource}>
+      {name}
+    </p>
+  )
+}
+
+export default Datasource

--- a/features/ati/AtiManuscript/DatasourceModal/DatasourceModal.module.css
+++ b/features/ati/AtiManuscript/DatasourceModal/DatasourceModal.module.css
@@ -1,9 +1,6 @@
-.datasource {
+.datasources {
   padding-top: 24px;
-  display: flex;
-  flex-direction: row;
-  justify-content: space-between;
-  align-items: center;
+  row-gap: 24px;
 }
 
 .datasourceModal {
@@ -19,11 +16,12 @@
   max-height: 100%;
 }
 
-.datasourceActions {
+.twoColumns {
   display: grid;
   grid-template-columns: 1fr auto;
   justify-content: space-between;
-  gap: 16px;
+  align-items: center;
+  column-gap: 16px;
 }
 
 .inlineLoading {

--- a/features/ati/AtiManuscript/DatasourceModal/DatasourceModal.stories.tsx
+++ b/features/ati/AtiManuscript/DatasourceModal/DatasourceModal.stories.tsx
@@ -18,6 +18,11 @@ Default.args = {
       name: "Datasource",
       uri: "https://datasource-uri.com",
     },
+    {
+      id: "datasource-id-2",
+      name: "Datasourcefffffff-fffffffffff_fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff.tab",
+      uri: "https://datasource-uri.com",
+    },
   ],
   datasetDoi: "dataset-doi",
   serverUrl: "https://test.com",

--- a/features/ati/AtiManuscript/DatasourceModal/index.tsx
+++ b/features/ati/AtiManuscript/DatasourceModal/index.tsx
@@ -1,4 +1,4 @@
-import { FC, useState } from "react"
+import React, { FC, useState } from "react"
 
 import axios from "axios"
 import { Renew20 } from "@carbon/icons-react"
@@ -15,6 +15,8 @@ import {
 import CopyToClipboard from "react-copy-to-clipboard"
 
 import useTask, { TaskActionType } from "../../../../hooks/useTask"
+
+import Datasource from "./Datasource"
 
 import { IDatasource } from "../../../../types/dataverse"
 import { getMessageFromError } from "../../../../utils/httpRequestUtils"
@@ -81,7 +83,7 @@ const DatasourceModal: FC<DatasourceModalProps> = ({
         aria-label="Data source URLs"
         hasScrollingContent={true}
       >
-        <div className={styles.datasourceActions} aria-live="assertive">
+        <div className={styles.twoColumns} aria-live="assertive">
           <Link
             href={`${serverUrl}/dataset.xhtml?persistentId=${datasetDoi}`}
             target="_blank"
@@ -118,23 +120,24 @@ const DatasourceModal: FC<DatasourceModalProps> = ({
             title="This project has no data sources."
           />
         )}
-        {datasourcesState.map(({ id, name, uri }) => (
-          <div
-            key={id}
-            className={styles.datasource}
-            aria-live="assertive"
-            aria-relevant="additions removals"
-          >
-            <p>{name}</p>
-            <CopyToClipboard key={id} text={uri}>
-              <CopyButton
-                feedback="Copied!"
-                feedbackTimeout={3000}
-                iconDescription="Copy URL to clipboard"
-              />
-            </CopyToClipboard>
-          </div>
-        ))}
+        <div
+          className={`${styles.datasources} ${styles.twoColumns}`}
+          aria-live="assertive"
+          aria-relevant="additions removals"
+        >
+          {datasourcesState.map(({ id, name, uri }) => (
+            <React.Fragment key={id}>
+              <Datasource name={name} />
+              <CopyToClipboard key={id} text={uri}>
+                <CopyButton
+                  feedback="Copied!"
+                  feedbackTimeout={3000}
+                  iconDescription="Copy URL to clipboard"
+                />
+              </CopyToClipboard>
+            </React.Fragment>
+          ))}
+        </div>
       </ModalBody>
     </ComposedModal>
   )


### PR DESCRIPTION
Resolves #72 

- Clip long data source names, so that it doesn't cause the copy button to be initially out of sight
- The full name of the data sources are visible on hover