### PR TITLE
feature/shareable-hypothesis-url

### DIFF
--- a/features/ati/AtiExportAnnotations/AtiExportAnnotations.module.css
+++ b/features/ati/AtiExportAnnotations/AtiExportAnnotations.module.css
@@ -25,7 +25,6 @@
 }
 
 .copyButton {
-  border-color: transparent;
   background-color: transparent;
 }
 

--- a/features/ati/AtiExportAnnotations/AtiExportAnnotations.module.css
+++ b/features/ati/AtiExportAnnotations/AtiExportAnnotations.module.css
@@ -21,7 +21,7 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  margin-right: 8px;
+  margin-right: 0.5rem;
 }
 
 .copyButton {

--- a/features/ati/AtiExportAnnotations/AtiExportAnnotations.module.css
+++ b/features/ati/AtiExportAnnotations/AtiExportAnnotations.module.css
@@ -16,3 +16,23 @@
   border: 1px solid red;
   border-radius: 10px;
 }
+
+.copyAction {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-right: 8px;
+}
+
+.copyButton {
+  border-color: transparent;
+  background-color: transparent;
+}
+
+.copyButton > svg {
+  fill: #0f62fe;
+}
+
+.copyButton:hover {
+  background-color: white;
+}

--- a/features/ati/AtiExportAnnotations/index.tsx
+++ b/features/ati/AtiExportAnnotations/index.tsx
@@ -11,7 +11,7 @@ import {
   Select,
   SelectItem,
   Toggle,
-  NotificationActionButton,
+  CopyButton,
 } from "carbon-components-react"
 import CopyToClipboard from "react-copy-to-clipboard"
 
@@ -136,11 +136,13 @@ const AtiExportAnnotations: FC<AtiExportAnnotationstProps> = ({
         exportHypothesisUrl.current = hypothesisUrl
         const payload = (
           <span>
-            {`Exported ${data.totalExported} annotation(s) to your`}{" "}
+            {`Exported ${data.totalExported} annotation(s). Your manuscript with annotation(s) can
+            be accessed at your`}{" "}
             <Link href={hypothesisUrl} size="md" target="_blank" rel="noopener noreferrer">
               <span>
                 destination <abbr>URL</abbr>
               </span>
+              .
             </Link>
           </span>
         )
@@ -236,13 +238,16 @@ const AtiExportAnnotations: FC<AtiExportAnnotationstProps> = ({
                 title={getTaskStatus(exportTaskState)}
                 actions={
                   exportTaskState.status === "finished" ? (
-                    <CopyToClipboard text={exportHypothesisUrl.current}>
-                      <NotificationActionButton>
-                        <span>
-                          Copy <abbr>URL</abbr>
-                        </span>
-                      </NotificationActionButton>
-                    </CopyToClipboard>
+                    <div className={styles.copyAction}>
+                      <CopyToClipboard text={exportHypothesisUrl.current}>
+                        <CopyButton
+                          className={styles.copyButton}
+                          feedback="Copied!"
+                          feedbackTimeout={3000}
+                          iconDescription="Copy URL to clipboard"
+                        />
+                      </CopyToClipboard>
+                    </div>
                   ) : undefined
                 }
               />

--- a/features/ati/AtiExportAnnotations/index.tsx
+++ b/features/ati/AtiExportAnnotations/index.tsx
@@ -136,9 +136,11 @@ const AtiExportAnnotations: FC<AtiExportAnnotationstProps> = ({
         exportHypothesisUrl.current = hypothesisUrl
         const payload = (
           <span>
-            {`Exported ${data.totalExported} annotation(s) to your`}
-            <Link href={hypothesisUrl} size="lg" target="_blank" rel="noopener noreferrer">
-              destination <abbr>URL</abbr>
+            {`Exported ${data.totalExported} annotation(s) to your`}{" "}
+            <Link href={hypothesisUrl} size="md" target="_blank" rel="noopener noreferrer">
+              <span>
+                destination <abbr>URL</abbr>
+              </span>
             </Link>
           </span>
         )
@@ -236,7 +238,9 @@ const AtiExportAnnotations: FC<AtiExportAnnotationstProps> = ({
                   exportTaskState.status === "finished" ? (
                     <CopyToClipboard text={exportHypothesisUrl.current}>
                       <NotificationActionButton>
-                        Copy <abbr>URL</abbr>
+                        <span>
+                          Copy <abbr>URL</abbr>
+                        </span>
                       </NotificationActionButton>
                     </CopyToClipboard>
                   ) : undefined

--- a/hooks/useTask/state.ts
+++ b/hooks/useTask/state.ts
@@ -1,8 +1,9 @@
 import { InlineLoadingStatus } from "carbon-components-react"
+import { ReactNode } from "react"
 
 export interface ITaskState {
   status: InlineLoadingStatus
-  desc: string
+  desc: ReactNode
 }
 
 export enum TaskActionType {
@@ -15,7 +16,7 @@ export enum TaskActionType {
 
 export type ITaskAction =
   | { type: TaskActionType.START; payload: string }
-  | { type: TaskActionType.FINISH; payload: string }
+  | { type: TaskActionType.FINISH; payload: ReactNode }
   | { type: TaskActionType.FAIL; payload: string }
   | { type: TaskActionType.NEXT_STEP; payload: string }
   | { type: TaskActionType.RESET }

--- a/hooks/useTask/state.ts
+++ b/hooks/useTask/state.ts
@@ -1,5 +1,5 @@
-import { InlineLoadingStatus } from "carbon-components-react"
 import { ReactNode } from "react"
+import { InlineLoadingStatus } from "carbon-components-react"
 
 export interface ITaskState {
   status: InlineLoadingStatus

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -14,11 +14,6 @@ a {
   box-sizing: border-box;
 }
 
-.bx--inline-notification {
-  width: 100% !important;
-  max-width: 100% !important;
-}
-
 .react-pdf__Page__textContent span {
   opacity: 0.25;
 }


### PR DESCRIPTION
Resvoles #73 

- On successful export annotations, included a [ `hyp.is/go`](https://github.com/hypothesis/bouncer#route-syntaxapi) URL in the success message
- Add an action button to copy the URL
- Revert all notification messages/banners back to their original length