### PR TITLE
feature/retry-post-ann

### DIFF
--- a/features/app/index.ts
+++ b/features/app/index.ts
@@ -1,6 +1,8 @@
 import axios from "axios"
 import axiosRetry from "axios-retry"
 
+const HYPOTHESIS_API_BASE_URL = process.env.HYPOTHESIS_SERVER_URL || "https://api.hypothes.is"
+
 const axiosClient = axios.create()
 axiosRetry(axiosClient, {
   retries: 5,
@@ -10,7 +12,7 @@ axiosRetry(axiosClient, {
       if (retryAfter) {
         return retryAfter
       }
-      if (error.response.status === 429 && error.config.url?.includes("hypothes.is")) {
+      if (error.response.status === 429 && error.config.url?.includes(HYPOTHESIS_API_BASE_URL)) {
         return retryCount * 1000 /** ms */
       }
     }
@@ -18,7 +20,7 @@ axiosRetry(axiosClient, {
   },
   retryCondition: (e) => {
     if (e.response) {
-      if (e.response.status === 429 && e.response.config.url?.includes("hypothes.is")) {
+      if (e.response.status === 429 && e.response.config.url?.includes(HYPOTHESIS_API_BASE_URL)) {
         return true
       }
     }

--- a/features/app/index.ts
+++ b/features/app/index.ts
@@ -1,0 +1,24 @@
+import axios from "axios"
+import axiosRetry from "axios-retry"
+
+const axiosClient = axios.create()
+axiosRetry(axiosClient, {
+  retries: 5,
+  retryDelay: (retryCount, error) => {
+    if (error.response) {
+      const retryAfter = error.response.headers["retry-after"]
+      if (retryAfter) {
+        return retryAfter
+      }
+      if (error.response.status === 429 && error.config.url?.includes("hypothes.is")) {
+        return retryCount * 1000 /** ms */
+      }
+    }
+    return axiosRetry.exponentialDelay(retryCount)
+  },
+  retryCondition: (e) => {
+    return axiosRetry.isNetworkOrIdempotentRequestError(e) || e.response?.status === 429
+  },
+})
+
+export { axiosClient }

--- a/features/app/index.ts
+++ b/features/app/index.ts
@@ -17,7 +17,12 @@ axiosRetry(axiosClient, {
     return axiosRetry.exponentialDelay(retryCount)
   },
   retryCondition: (e) => {
-    return axiosRetry.isNetworkOrIdempotentRequestError(e) || e.response?.status === 429
+    if (e.response) {
+      if (e.response.status === 429 && e.response.config.url?.includes("hypothes.is")) {
+        return true
+      }
+    }
+    return axiosRetry.isNetworkOrIdempotentRequestError(e)
   },
 })
 

--- a/features/ati/AtiExportAnnotations/index.tsx
+++ b/features/ati/AtiExportAnnotations/index.tsx
@@ -1,6 +1,5 @@
 import { FC, useState, FormEventHandler, useEffect, useRef } from "react"
 
-import axios from "axios"
 import { Export16, TrashCan16 } from "@carbon/icons-react"
 import {
   Link,
@@ -14,6 +13,8 @@ import {
   CopyButton,
 } from "carbon-components-react"
 import CopyToClipboard from "react-copy-to-clipboard"
+
+import { axiosClient } from "../../app"
 
 import { AtiTab } from "../../../constants/ati"
 import { HYPOTHESIS_PUBLIC_GROUP_ID } from "../../../constants/hypothesis"
@@ -69,7 +70,7 @@ const AtiExportAnnotations: FC<AtiExportAnnotationstProps> = ({
   useEffect(() => {
     let didCancel = false
     const getAnnotationsJson = async () => {
-      const { data } = await axios.get(`/api/hypothesis/${datasetId}/download-annotations`, {
+      const { data } = await axiosClient.get(`/api/hypothesis/${datasetId}/download-annotations`, {
         params: {
           hypothesisGroup: HYPOTHESIS_PUBLIC_GROUP_ID,
           isAdminAuthor: false,
@@ -103,7 +104,7 @@ const AtiExportAnnotations: FC<AtiExportAnnotationstProps> = ({
     }
 
     exportTaskDispatch({ type: TaskActionType.START, payload: "Downloading annotations..." })
-    await axios
+    await axiosClient
       .get(`/api/hypothesis/${datasetId}/download-annotations`, {
         params: {
           hypothesisGroup:
@@ -115,7 +116,7 @@ const AtiExportAnnotations: FC<AtiExportAnnotationstProps> = ({
       })
       .then(({ data }) => {
         exportTaskDispatch({ type: TaskActionType.NEXT_STEP, payload: "Exporting annotations..." })
-        return axios.post(
+        return axiosClient.post(
           `/api/hypothesis/${datasetId}/export-annotations`,
           JSON.stringify({
             isAdminAuthor: false,
@@ -172,7 +173,7 @@ const AtiExportAnnotations: FC<AtiExportAnnotationstProps> = ({
   const handleDeleteAnnotations = async () => {
     closeDeleteAnnotationsModal()
     deleteTaskDispatch({ type: TaskActionType.START, payload: "Downloading annotations..." })
-    await axios
+    await axiosClient
       .get(`/api/hypothesis/${datasetId}/download-annotations`, {
         params: {
           hypothesisGroup: deleteAnnotationsHypothesisGroup,
@@ -184,7 +185,7 @@ const AtiExportAnnotations: FC<AtiExportAnnotationstProps> = ({
           type: TaskActionType.NEXT_STEP,
           payload: `Deleting ${data.annotations.length} annotation(s)...`,
         })
-        return axios.delete(`/api/hypothesis/${datasetId}/delete-annotations`, {
+        return axiosClient.delete(`/api/hypothesis/${datasetId}/delete-annotations`, {
           data: JSON.stringify({ annotations: data.annotations }),
           params: {
             isAdminAuthor: false,

--- a/features/ati/AtiManuscript/index.tsx
+++ b/features/ati/AtiManuscript/index.tsx
@@ -1,10 +1,11 @@
 import { FC, FormEventHandler, useReducer, ChangeEvent } from "react"
 
-import axios from "axios"
 import { Button, Form, FileUploader, InlineNotification, Toggle } from "carbon-components-react"
 import FormData from "form-data"
 import { DocumentAdd20, TrashCan20, Upload16 } from "@carbon/icons-react"
 import { useRouter } from "next/router"
+
+import { axiosClient } from "../../app"
 
 import DatasourceModal from "./DatasourceModal"
 import DeleteManuscriptModal from "./DeleteManuscriptModal"
@@ -72,7 +73,7 @@ const AtiManuscript: FC<AtiManuscriptProps> = ({
   const handleDeleteManuscript = async () => {
     closeDeleteManuscriptModal()
     taskDispatch({ type: TaskActionType.START, payload: "Deleting manuscript..." })
-    await axios
+    await axiosClient
       .delete(`/api/delete-file/${manuscript.id}`)
       .then(() => {
         taskDispatch({ type: TaskActionType.FINISH, payload: `Deleted ${manuscript.name}.` })
@@ -142,7 +143,7 @@ const AtiManuscript: FC<AtiManuscriptProps> = ({
         type: TaskActionType.START,
         payload: `Uploading ${uploadManuscriptTaskState.manuscript.name}...`,
       })
-      await axios({
+      await axiosClient({
         method: "POST",
         url: `/api/datasets/${datasetId}/manuscript`,
         data: formData,
@@ -153,7 +154,7 @@ const AtiManuscript: FC<AtiManuscriptProps> = ({
         .then(async ({ data }) => {
           const newManuscriptId = data.data.files[0].dataFile.id
           const deleteAnnotationsPromise = uploadManuscriptTaskState.uploadAnnotations
-            ? axios({
+            ? axiosClient({
                 method: "GET",
                 url: `/api/hypothesis/${datasetId}/download-annotations`,
                 params: {
@@ -166,7 +167,7 @@ const AtiManuscript: FC<AtiManuscriptProps> = ({
                     type: TaskActionType.NEXT_STEP,
                     payload: `Deleting current annotation(s) from Hypothes.is server...`,
                   })
-                  return axios({
+                  return axiosClient({
                     method: "DELETE",
                     url: `/api/hypothesis/${datasetId}/delete-annotations`,
                     data: JSON.stringify({ annotations: data.annotations }),
@@ -189,7 +190,7 @@ const AtiManuscript: FC<AtiManuscriptProps> = ({
                   : "Creating ingest PDF"
               } from ${uploadManuscriptTaskState.manuscript?.name}...`,
             })
-            return axios({
+            return axiosClient({
               method: "PUT",
               url: `/api/arcore/${newManuscriptId}`,
               params: {

--- a/features/ati/AtiProjects/useSearch.ts
+++ b/features/ati/AtiProjects/useSearch.ts
@@ -1,7 +1,8 @@
 import { Dispatch, useEffect, useReducer } from "react"
 
-import axios from "axios"
 import qs from "qs"
+
+import { axiosClient } from "../../app"
 
 import { SearchActionType, ISearchAction, searchReducer, ISearchState } from "./state"
 import { getTrueFields } from "./utils"
@@ -23,7 +24,7 @@ const useSearch = (inititalState: ISearchState): [ISearchState, Dispatch<ISearch
         const publicationStatuses = state.fetchQ
           ? PUBLICATION_STATUSES
           : getTrueFields(state.selectedPublicationStatuses)
-        const { data } = await axios.get<IMyDataSearch>(`/api/mydata-search`, {
+        const { data } = await axiosClient.get<IMyDataSearch>(`/api/mydata-search`, {
           params: {
             publicationStatuses,
             q: state.q,

--- a/features/ati/AtiSettings/index.tsx
+++ b/features/ati/AtiSettings/index.tsx
@@ -1,9 +1,10 @@
 import { FC, FormEventHandler } from "react"
 
-import axios from "axios"
 import { TrashCan16 } from "@carbon/icons-react"
 import { Button, Form, InlineNotification } from "carbon-components-react"
 import { useRouter } from "next/router"
+
+import { axiosClient } from "../../app"
 
 import DeleteAtiModal from "./DeleteAtiModal"
 
@@ -41,7 +42,7 @@ const AtiSettings: FC<AtiSettingsProps> = ({ dataset, manuscript }) => {
   const handleDeleteAti = async () => {
     closeDeleteAtiModal()
     taskDispatch({ type: TaskActionType.START, payload: "Deleting ATI project..." })
-    await axios
+    await axiosClient
       .put(`/api/datasets/${dataset.id}/annorep/delete`)
       .then(() => {
         if (manuscript.id) {
@@ -49,13 +50,13 @@ const AtiSettings: FC<AtiSettingsProps> = ({ dataset, manuscript }) => {
             type: TaskActionType.NEXT_STEP,
             payload: `Deleting manuscript ${manuscript.name}...`,
           })
-          return axios.delete(`/api/delete-file/${manuscript.id}`)
+          return axiosClient.delete(`/api/delete-file/${manuscript.id}`)
         } else {
           return Promise.resolve<any>("Skip!")
         }
       })
       .then(() => {
-        return axios.get(`/api/hypothesis/${dataset.id}/download-annotations`, {
+        return axiosClient.get(`/api/hypothesis/${dataset.id}/download-annotations`, {
           params: { hypothesisGroup: "", isAdminAuthor: false },
         })
       })
@@ -65,7 +66,7 @@ const AtiSettings: FC<AtiSettingsProps> = ({ dataset, manuscript }) => {
             type: TaskActionType.NEXT_STEP,
             payload: "Deleting annotations from Hypothes.is server...",
           })
-          return axios.delete(`/api/hypothesis/${dataset.id}/delete-annotations`, {
+          return axiosClient.delete(`/api/hypothesis/${dataset.id}/delete-annotations`, {
             data: JSON.stringify({ annotations: data.annotations }),
             params: {
               isAdminAuthor: false,

--- a/features/ati/AtiSummary/index.tsx
+++ b/features/ati/AtiSummary/index.tsx
@@ -1,5 +1,4 @@
 import { FC } from "react"
-import axios from "axios"
 import {
   UnorderedList,
   ListItem,
@@ -10,6 +9,8 @@ import {
 } from "carbon-components-react"
 import { Launch16 } from "@carbon/icons-react"
 import { useRouter } from "next/router"
+
+import { axiosClient } from "../../app"
 
 import { AtiTab } from "../../../constants/ati"
 import { PUBLICATION_STATUSES_COLOR } from "../../../constants/dataverse"
@@ -55,23 +56,26 @@ const AtiSummary: FC<AtiSummaryProps> = ({
     try {
       taskDispatch({ type: TaskActionType.START, payload: "Submitting project for review..." })
 
-      const submitForReviewPromise = axios.post(`/api/datasets/${id}/submit-for-review`)
+      const submitForReviewPromise = axiosClient.post(`/api/datasets/${id}/submit-for-review`)
 
-      const getAtiStagingAnnotationsPromise = axios.get(
+      const getAtiStagingAnnotationsPromise = axiosClient.get(
         `/api/hypothesis/${id}/download-annotations`,
         {
           params: { hypothesisGroup: hypothesisAtiStagingGroupId, isAdminAuthor: true },
         }
       )
-      const getUserAnnotationsPromise = axios.get(`/api/hypothesis/${id}/download-annotations`, {
-        params: { hypothesisGroup: HYPOTHESIS_PUBLIC_GROUP_ID, isAdminAuthor: false },
-      })
+      const getUserAnnotationsPromise = axiosClient.get(
+        `/api/hypothesis/${id}/download-annotations`,
+        {
+          params: { hypothesisGroup: HYPOTHESIS_PUBLIC_GROUP_ID, isAdminAuthor: false },
+        }
+      )
       const [getAtiStagingAnnotationsResult, getUserAnnotationsResult] = await Promise.all([
         getAtiStagingAnnotationsPromise,
         getUserAnnotationsPromise,
       ])
 
-      const deleteAtiStagingAnnotationsPromise = axios.delete(
+      const deleteAtiStagingAnnotationsPromise = axiosClient.delete(
         `/api/hypothesis/${id}/delete-annotations`,
         {
           data: JSON.stringify({ annotations: getAtiStagingAnnotationsResult.data.annotations }),
@@ -83,7 +87,7 @@ const AtiSummary: FC<AtiSummaryProps> = ({
           },
         }
       )
-      const exportUserAnnotationsPromise = axios.post(
+      const exportUserAnnotationsPromise = axiosClient.post(
         `/api/hypothesis/${id}/export-annotations`,
         JSON.stringify({
           isAdminAuthor: true,

--- a/features/ati/NewAtiProjectForm/index.tsx
+++ b/features/ati/NewAtiProjectForm/index.tsx
@@ -9,7 +9,6 @@ import React, {
 } from "react"
 
 import FormData from "form-data"
-import axios from "axios"
 import { Add16, OverflowMenuVertical24 } from "@carbon/icons-react"
 import {
   Button,
@@ -23,6 +22,8 @@ import {
 } from "carbon-components-react"
 import { debounce } from "lodash"
 import { useRouter } from "next/router"
+
+import { axiosClient } from "../../app"
 
 import { ManuscriptFileExtension, ManuscriptMimeType } from "../../../constants/arcore"
 import { AtiTab } from "../../../constants/ati"
@@ -133,13 +134,13 @@ const NewAtiProjectForm: FC<NewAtiProjectFormProps> = ({
     const formData = new FormData()
     formData.append("manuscript", manuscript)
     taskDispatch({ type: TaskActionType.START, payload: "Creating ATI project..." })
-    await axios({
+    await axiosClient({
       method: "PUT",
       url: `/api/datasets/${selectedDataset?.id}/annorep`,
     })
       .then(() => {
         taskDispatch({ type: TaskActionType.NEXT_STEP, payload: `Uploading ${manuscript.name}...` })
-        return axios({
+        return axiosClient({
           method: "POST",
           url: `/api/datasets/${selectedDataset?.id}/manuscript`,
           data: formData,
@@ -154,7 +155,7 @@ const NewAtiProjectForm: FC<NewAtiProjectFormProps> = ({
           payload: `Extracting annotations from ${manuscript.name}...`,
         })
         const manuscriptId = data.data.files[0].dataFile.id
-        return axios({
+        return axiosClient({
           method: "PUT",
           url: `/api/arcore/${manuscriptId}`,
           params: {

--- a/features/ati/NewAtiProjectForm/useDatasetSearch.ts
+++ b/features/ati/NewAtiProjectForm/useDatasetSearch.ts
@@ -1,7 +1,8 @@
 import { Dispatch, useEffect, useReducer } from "react"
 
-import axios from "axios"
 import qs from "qs"
+
+import { axiosClient } from "../../app"
 
 import {
   ISearchDatasetAction,
@@ -25,7 +26,7 @@ const useSearchDataset = (
     const search = async () => {
       try {
         dispatch({ type: SearchDatasetActionType.SEARCH_INIT })
-        const { data } = await axios.get<IMyDataSearch>(`/api/mydata-search`, {
+        const { data } = await axiosClient.get<IMyDataSearch>(`/api/mydata-search`, {
           params: {
             q: state.q,
             //dataverse mydata selected_page starts at 1

--- a/package-lock.json
+++ b/package-lock.json
@@ -10661,6 +10661,25 @@
         "follow-redirects": "^1.10.0"
       }
     },
+    "axios-retry": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-3.2.4.tgz",
+      "integrity": "sha512-Co3UXiv4npi6lM963mfnuH90/YFLKWWDmoBYfxkHT5xtkSSWNqK9zdG3fw5/CP/dsoKB5aMMJCsgab+tp1OxLQ==",
+      "requires": {
+        "@babel/runtime": "^7.15.4",
+        "is-retry-allowed": "^2.2.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.17.8",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.8.tgz",
+          "integrity": "sha512-dQpEpK0O9o6lj6oPu0gRDbbnk+4LeHlNcBpspf6Olzt3GIX4P1lWF1gS+pHLDFlaJvbR6q7jCfQ08zA4QJBnmA==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
     "axobject-query": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",
@@ -17307,6 +17326,11 @@
       "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
       "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk=",
       "dev": true
+    },
+    "is-retry-allowed": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-2.2.0.tgz",
+      "integrity": "sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg=="
     },
     "is-root": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@types/carbon-components-react": "^7.44.0",
     "@types/carbon__icons-react": "^10.31.2",
     "axios": "^0.21.1",
+    "axios-retry": "^3.2.4",
     "carbon-components": "^10.45.0",
     "carbon-components-react": "^7.45.0",
     "carbon-icons": "^7.0.7",

--- a/pages/api/arcore/[id]/index.ts
+++ b/pages/api/arcore/[id]/index.ts
@@ -1,6 +1,8 @@
-import axios, { AxiosPromise } from "axios"
+import { AxiosPromise } from "axios"
 import { NextApiRequest, NextApiResponse } from "next"
 import { getSession } from "next-auth/client"
+
+import { axiosClient } from "../../../../features/app"
 
 import { AtiTab } from "../../../../constants/ati"
 import { DATAVERSE_HEADER_NAME } from "../../../../constants/dataverse"
@@ -14,7 +16,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     if (session) {
       const { id } = req.query
       const { dataverseApiToken, hypothesisApiToken } = session
-      const createPdfAnn = axios({
+      const createPdfAnn = axiosClient({
         method: "PUT",
         url: `${process.env.ARCORE_SERVER_URL}/api/documents/${id}`,
         headers: {
@@ -24,7 +26,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       })
       await createPdfAnn
         .then(() => {
-          return axios({
+          return axiosClient({
             method: "GET",
             url: `${process.env.ARCORE_SERVER_URL}/api/documents/${id}/ann`,
             headers: {
@@ -41,7 +43,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
               annotation.target.forEach((element: any) => {
                 element.source = uri
               })
-              return axios({
+              return axiosClient({
                 method: "POST",
                 url: `${process.env.HYPOTHESIS_SERVER_URL}/api/annotations`,
                 data: JSON.stringify({

--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -1,6 +1,7 @@
-import axios from "axios"
 import NextAuth from "next-auth"
 import Providers from "next-auth/providers"
+
+import { axiosClient } from "../../../features/app"
 
 import { DATAVERSE_HEADER_NAME } from "../../../constants/dataverse"
 import { INVALID_HYPOTHESIS_API_TOKEN, LOGIN_ID } from "../../../features/auth/constants"
@@ -30,7 +31,7 @@ export default NextAuth({
         }
         let dataverseErrorMsg
         try {
-          const { status, data } = await axios.get(
+          const { status, data } = await axiosClient.get(
             `${process.env.DATAVERSE_SERVER_URL}/api/users/:me`,
             {
               headers: {
@@ -46,11 +47,14 @@ export default NextAuth({
           dataverseErrorMsg = (e as any).response.data.message
         }
         try {
-          const { data } = await axios.get(`${process.env.HYPOTHESIS_SERVER_URL}/api/profile`, {
-            headers: {
-              Authorization: `Bearer ${creds.hypothesisApiToken.trim()}`,
-            },
-          })
+          const { data } = await axiosClient.get(
+            `${process.env.HYPOTHESIS_SERVER_URL}/api/profile`,
+            {
+              headers: {
+                Authorization: `Bearer ${creds.hypothesisApiToken.trim()}`,
+              },
+            }
+          )
           if (data.userid !== null) {
             user.hypothesisApiToken = creds.hypothesisApiToken.trim()
             user.hypothesisUserId = data.userid

--- a/pages/api/datasets/[id]/annorep/delete.ts
+++ b/pages/api/datasets/[id]/annorep/delete.ts
@@ -1,6 +1,7 @@
-import axios from "axios"
 import { NextApiRequest, NextApiResponse } from "next"
 import { getSession } from "next-auth/client"
+
+import { axiosClient } from "../../../../../features/app"
 
 import {
   ANNOREP_METADATA_FIELD,
@@ -17,7 +18,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       const { id } = req.query
       const requestDesc = `Deleting ${ANNOREP_METADATA_VALUE} metadata from data project ${id}`
       try {
-        const { status, data } = await axios({
+        const { status, data } = await axiosClient({
           method: "PUT",
           url: `${process.env.DATAVERSE_SERVER_URL}/api/datasets/${id}/metadata/delete`,
           data: JSON.stringify({

--- a/pages/api/datasets/[id]/annorep/index.ts
+++ b/pages/api/datasets/[id]/annorep/index.ts
@@ -1,6 +1,7 @@
-import axios from "axios"
 import { NextApiRequest, NextApiResponse } from "next"
 import { getSession } from "next-auth/client"
+
+import { axiosClient } from "../../../../../features/app"
 
 import {
   ANNOREP_METADATA_FIELD,
@@ -17,7 +18,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       const { id } = req.query
       const requestDesc = `Adding ${ANNOREP_METADATA_VALUE} metadata to data project ${id}`
       try {
-        const { status, data } = await axios({
+        const { status, data } = await axiosClient({
           method: "PUT",
           url: `${process.env.DATAVERSE_SERVER_URL}/api/datasets/${id}/metadata`,
           params: {

--- a/pages/api/datasets/[id]/data-files.ts
+++ b/pages/api/datasets/[id]/data-files.ts
@@ -1,6 +1,7 @@
-import axios from "axios"
 import { NextApiRequest, NextApiResponse } from "next"
 import { getSession } from "next-auth/client"
+
+import { axiosClient } from "../../../../features/app"
 
 import { DATAVERSE_HEADER_NAME } from "../../../../constants/dataverse"
 import { REQUEST_DESC_HEADER_NAME } from "../../../../constants/http"
@@ -13,7 +14,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       const { id } = req.query
       const requestDesc = `Getting data files for data project ${id}`
       try {
-        const { status, data } = await axios({
+        const { status, data } = await axiosClient({
           method: "GET",
           url: `${process.env.DATAVERSE_SERVER_URL}/api/datasets/${id}`,
           headers: {

--- a/pages/api/datasets/[id]/manuscript/index.ts
+++ b/pages/api/datasets/[id]/manuscript/index.ts
@@ -1,9 +1,10 @@
-import axios from "axios"
 import formidable from "formidable"
 import FormData from "form-data"
 import fs from "fs"
 import { NextApiRequest, NextApiResponse } from "next"
 import { getSession } from "next-auth/client"
+
+import { axiosClient } from "../../../../../features/app"
 
 import {
   ANNOREP_METADATA_VALUE,
@@ -52,7 +53,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
                 restrict: true,
               })
             )
-            const { status, data } = await axios({
+            const { status, data } = await axiosClient({
               method: "POST",
               url: `${process.env.DATAVERSE_SERVER_URL}/api/datasets/${id}/add`,
               data: addManuscriptForm,

--- a/pages/api/datasets/[id]/submit-for-review.ts
+++ b/pages/api/datasets/[id]/submit-for-review.ts
@@ -1,6 +1,7 @@
-import axios from "axios"
 import { NextApiRequest, NextApiResponse } from "next"
 import { getSession } from "next-auth/client"
+
+import { axiosClient } from "../../../../features/app"
 
 import { DATAVERSE_HEADER_NAME } from "../../../../constants/dataverse"
 import { REQUEST_DESC_HEADER_NAME } from "../../../../constants/http"
@@ -13,7 +14,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       const { id } = req.query
       const requestDesc = `Submitting data project ${id} for review`
       try {
-        const { status, data } = await axios({
+        const { status, data } = await axiosClient({
           method: "POST",
           url: `${process.env.DATAVERSE_SERVER_URL}/api/datasets/${id}/submitForReview`,
           headers: {

--- a/pages/api/delete-file/[id].ts
+++ b/pages/api/delete-file/[id].ts
@@ -1,6 +1,8 @@
-import axios from "axios"
 import { NextApiRequest, NextApiResponse } from "next"
 import { getSession } from "next-auth/client"
+
+import { axiosClient } from "../../../features/app"
+
 import { getResponseFromError } from "../../../utils/httpRequestUtils"
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse): Promise<void> {
@@ -10,7 +12,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       const { id } = req.query
       const { dataverseApiToken } = session
       try {
-        const { status, data } = await axios({
+        const { status, data } = await axiosClient({
           method: "DELETE",
           url: `${process.env.DATAVERSE_SERVER_URL}/dvn/api/data-deposit/v1.1/swordv2/edit-media/file/${id}`,
           auth: {

--- a/pages/api/hypothesis/[id]/delete-annotations.ts
+++ b/pages/api/hypothesis/[id]/delete-annotations.ts
@@ -1,6 +1,8 @@
-import axios, { AxiosPromise } from "axios"
+import { AxiosPromise } from "axios"
 import { NextApiRequest, NextApiResponse } from "next"
 import { getSession } from "next-auth/client"
+
+import { axiosClient } from "../../../../features/app"
 
 import { REQUEST_DESC_HEADER_NAME } from "../../../../constants/http"
 import { getResponseFromError } from "../../../../utils/httpRequestUtils"
@@ -8,7 +10,7 @@ import { getResponseFromError } from "../../../../utils/httpRequestUtils"
 export default async function handler(req: NextApiRequest, res: NextApiResponse): Promise<void> {
   if (req.method === "DELETE") {
     const session = await getSession({ req })
-    const { data } = await axios.get(`${process.env.HYPOTHESIS_SERVER_URL}/api/profile`, {
+    const { data } = await axiosClient.get(`${process.env.HYPOTHESIS_SERVER_URL}/api/profile`, {
       headers: { Authorization: `Bearer ${process.env.ADMIN_HYPOTHESIS_API_TOKEN}` },
     })
     if (session) {
@@ -28,7 +30,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
           annotation.permissions.delete.includes(hypothesisUserId)
         )
         const deleteAnns: AxiosPromise<any>[] = deletableAnnotations.map((annotation: any) => {
-          return axios.delete(
+          return axiosClient.delete(
             `${process.env.HYPOTHESIS_SERVER_URL}/api/annotations/${annotation.id}`,
             {
               headers: {

--- a/pages/api/hypothesis/[id]/download-annotations.ts
+++ b/pages/api/hypothesis/[id]/download-annotations.ts
@@ -1,6 +1,7 @@
-import axios from "axios"
 import { NextApiRequest, NextApiResponse } from "next"
 import { getSession } from "next-auth/client"
+
+import { axiosClient } from "../../../../features/app"
 
 import { AtiTab } from "../../../../constants/ati"
 import { REQUEST_DESC_HEADER_NAME } from "../../../../constants/http"
@@ -21,7 +22,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       const hypothesisApiToken =
         isAdminAuthor === "true" ? ADMIN_HYPOTHESIS_API_TOKEN : userHypothesisApiToken
       const requestDesc = `Getting annotations from Hypothes.is server for data project ${id}`
-      await axios
+      await axiosClient
         //Get the total annotations
         .get(searchEndpoint, {
           params: {
@@ -40,7 +41,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
           const offsets = range(0, data.total - 1, ANNOTATIONS_MAX_LIMIT)
           return Promise.all(
             offsets.map((offset) => {
-              return axios.get(searchEndpoint, {
+              return axiosClient.get(searchEndpoint, {
                 params: {
                   limit: ANNOTATIONS_MAX_LIMIT,
                   group: hypothesisGroup,

--- a/pages/api/hypothesis/[id]/export-annotations.ts
+++ b/pages/api/hypothesis/[id]/export-annotations.ts
@@ -1,6 +1,8 @@
-import axios, { AxiosPromise } from "axios"
+import { AxiosPromise } from "axios"
 import { NextApiRequest, NextApiResponse } from "next"
 import { getSession } from "next-auth/client"
+
+import { axiosClient } from "../../../../features/app"
 
 import { REQUEST_DESC_HEADER_NAME } from "../../../../constants/http"
 import { getResponseFromError } from "../../../../utils/httpRequestUtils"
@@ -27,7 +29,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
           if (!privateAnnotation) {
             newReadPermission = [`group:${destinationHypothesisGroup}`]
           }
-          return axios({
+          return axiosClient({
             method: "POST",
             url: `${process.env.HYPOTHESIS_SERVER_URL}/api/annotations`,
             data: JSON.stringify({

--- a/pages/api/mydata-search.ts
+++ b/pages/api/mydata-search.ts
@@ -1,7 +1,8 @@
-import axios from "axios"
 import { NextApiRequest, NextApiResponse } from "next"
 import { getSession } from "next-auth/client"
 import qs from "qs"
+
+import { axiosClient } from "../../features/app"
 
 import {
   ANNOREP_METADATA_VALUE,
@@ -27,7 +28,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         searchTerm = searchTerm + ` AND ${q}`
       }
       try {
-        const { data } = await axios.get(
+        const { data } = await axiosClient.get(
           `${process.env.DATAVERSE_SERVER_URL}/api/mydata/retrieve`,
           {
             params: {

--- a/pages/ati/[id]/exportAnnotations.tsx
+++ b/pages/ati/[id]/exportAnnotations.tsx
@@ -1,8 +1,10 @@
 import { FC } from "react"
 
-import axios, { AxiosResponse } from "axios"
+import { AxiosResponse } from "axios"
 import { GetServerSideProps } from "next"
 import { getSession } from "next-auth/client"
+
+import { axiosClient } from "../../../features/app"
 
 import AtiExportAnnotations from "../../../features/ati/AtiExportAnnotations"
 import AtiTab from "../../../features/ati/AtiTab"
@@ -68,7 +70,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
   if (session) {
     const { dataverseApiToken, hypothesisApiToken } = session
     //Get the dataset json
-    await axios
+    await axiosClient
       .get(`${process.env.DATAVERSE_SERVER_URL}/api/datasets/${datasetId}`, {
         headers: {
           [DATAVERSE_HEADER_NAME]: dataverseApiToken,
@@ -88,7 +90,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
         )
         if (manuscript && manuscript.dataFile.id) {
           //Get the ingest pdf
-          return axios.get(
+          return axiosClient.get(
             `${process.env.ARCORE_SERVER_URL}/api/documents/${manuscript.dataFile.id}/pdf`,
             {
               responseType: "arraybuffer",
@@ -114,7 +116,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
     }
 
     try {
-      const { data } = await axios.get(`${process.env.HYPOTHESIS_SERVER_URL}/api/groups`, {
+      const { data } = await axiosClient.get(`${process.env.HYPOTHESIS_SERVER_URL}/api/groups`, {
         headers: {
           Authorization: `Bearer ${hypothesisApiToken}`,
           Accept: "application/json",

--- a/pages/ati/[id]/manuscript.tsx
+++ b/pages/ati/[id]/manuscript.tsx
@@ -1,8 +1,10 @@
 import { FC } from "react"
 
-import axios, { AxiosResponse } from "axios"
+import { AxiosResponse } from "axios"
 import { GetServerSideProps } from "next"
 import { getSession } from "next-auth/client"
+
+import { axiosClient } from "../../../features/app"
 
 import AtiManuscript from "../../../features/ati/AtiManuscript"
 import AtiTab from "../../../features/ati/AtiTab"
@@ -64,7 +66,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
   if (session) {
     const { dataverseApiToken } = session
     //Get the dataset json
-    await axios
+    await axiosClient
       .get(`${process.env.DATAVERSE_SERVER_URL}/api/datasets/${datasetId}`, {
         headers: {
           [DATAVERSE_HEADER_NAME]: dataverseApiToken,
@@ -83,7 +85,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
         )
         if (manuscript && manuscript.dataFile.id) {
           //Get the ingest pdf
-          return axios.get(
+          return axiosClient.get(
             `${process.env.ARCORE_SERVER_URL}/api/documents/${manuscript.dataFile.id}/pdf`,
             {
               responseType: "arraybuffer",

--- a/pages/ati/[id]/summary.tsx
+++ b/pages/ati/[id]/summary.tsx
@@ -1,9 +1,11 @@
 import { FC } from "react"
 
-import axios, { AxiosResponse } from "axios"
+import { AxiosResponse } from "axios"
 import { GetServerSideProps } from "next"
 import { getSession } from "next-auth/client"
 import qs from "qs"
+
+import { axiosClient } from "../../../features/app"
 
 import AtiSummary from "../../../features/ati/AtiSummary"
 import AtiTab from "../../../features/ati/AtiTab"
@@ -75,7 +77,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
   if (session) {
     const { dataverseApiToken } = session
     //Get the dataset json
-    await axios
+    await axiosClient
       .get(`${process.env.DATAVERSE_SERVER_URL}/api/datasets/${datasetId}`, {
         headers: {
           [DATAVERSE_HEADER_NAME]: dataverseApiToken,
@@ -87,7 +89,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
         responses.push(datasetJsonResponse)
         const dsPersistentId = datasetJsonResponse.data.data.latestVersion.datasetPersistentId
         const promises = [
-          axios.get(`${process.env.DATAVERSE_SERVER_URL}/api/mydata/retrieve`, {
+          axiosClient.get(`${process.env.DATAVERSE_SERVER_URL}/api/mydata/retrieve`, {
             params: {
               key: dataverseApiToken,
               dvobject_types: DATASET_DV_TYPE,
@@ -106,7 +108,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
         if (latest.files.length > 0) {
           //Get the dataset zip
           promises.push(
-            axios.get(`${process.env.DATAVERSE_SERVER_URL}/api/access/dataset/${datasetId}`, {
+            axiosClient.get(`${process.env.DATAVERSE_SERVER_URL}/api/access/dataset/${datasetId}`, {
               responseType: "arraybuffer",
               headers: {
                 [DATAVERSE_HEADER_NAME]: dataverseApiToken,

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,11 +1,12 @@
 import { FC } from "react"
 
-import axios from "axios"
 import { InlineNotification, NotificationActionButton } from "carbon-components-react"
 import { GetServerSideProps } from "next"
 import { getSession } from "next-auth/client"
 import { useRouter } from "next/router"
 import qs from "qs"
+
+import { axiosClient } from "../features/app"
 
 import AtiProjects from "../features/ati/AtiProjects"
 import AppGuide from "../features/components/AppGuide"
@@ -93,20 +94,23 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
   }
   if (session) {
     try {
-      const { data } = await axios.get(`${process.env.DATAVERSE_SERVER_URL}/api/mydata/retrieve`, {
-        params: {
-          key: session.dataverseApiToken,
-          dvobject_types: DATASET_DV_TYPE,
-          published_states: PUBLICATION_STATUSES,
-          mydata_search_term: `${KIND_OF_DATA_NAME}:${ANNOREP_METADATA_VALUE}`,
-        },
-        paramsSerializer: (params) => {
-          return qs.stringify(params, { indices: false })
-        },
-        headers: {
-          [REQUEST_DESC_HEADER_NAME]: `Searching for ${ANNOREP_METADATA_VALUE} data projects`,
-        },
-      })
+      const { data } = await axiosClient.get(
+        `${process.env.DATAVERSE_SERVER_URL}/api/mydata/retrieve`,
+        {
+          params: {
+            key: session.dataverseApiToken,
+            dvobject_types: DATASET_DV_TYPE,
+            published_states: PUBLICATION_STATUSES,
+            mydata_search_term: `${KIND_OF_DATA_NAME}:${ANNOREP_METADATA_VALUE}`,
+          },
+          paramsSerializer: (params) => {
+            return qs.stringify(params, { indices: false })
+          },
+          headers: {
+            [REQUEST_DESC_HEADER_NAME]: `Searching for ${ANNOREP_METADATA_VALUE} data projects`,
+          },
+        }
+      )
       if (data.success) {
         const items = data.data.items
         for (let i = 0; i < items.length; i++) {

--- a/pages/new/index.tsx
+++ b/pages/new/index.tsx
@@ -1,10 +1,11 @@
 import { FC } from "react"
 
-import axios from "axios"
 import { InlineNotification } from "carbon-components-react"
 import { getSession } from "next-auth/client"
 import { GetServerSideProps } from "next"
 import qs from "qs"
+
+import { axiosClient } from "../../features/app"
 
 import NewAtiProjectForm from "../../features/ati/NewAtiProjectForm"
 import Layout from "../../features/components/Layout"
@@ -64,7 +65,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
   }
   if (session) {
     try {
-      const { data } = await axios.get(
+      const { data } = await axiosClient.get(
         //TODO: change to X-Dataverse-key header later
         `${process.env.DATAVERSE_SERVER_URL}/api/mydata/retrieve`,
         {


### PR DESCRIPTION
There is request rate limit for the Hypothesis API -- around 40 requests/sec.

This causes creating many annotations to error out. This PR adds a retry method in cases where a request to Hypothesis received a 429 error code. When received a 429 error code, wait 1s and then try again. AnnoRep will try 5 more times and in each iteration the delay between each try is `retryCount * 1s`.