### PR TITLE
fix/hypothesis-rate-limit-error

### DIFF
--- a/constants/hypothesis.ts
+++ b/constants/hypothesis.ts
@@ -1,1 +1,3 @@
 export const HYPOTHESIS_PUBLIC_GROUP_ID = "__world__"
+
+export const REQUEST_BATCH_SIZE = 30

--- a/constants/hypothesis.ts
+++ b/constants/hypothesis.ts
@@ -1,3 +1,5 @@
 export const HYPOTHESIS_PUBLIC_GROUP_ID = "__world__"
 
 export const REQUEST_BATCH_SIZE = 30
+
+export const ANNOTATIONS_MAX_LIMIT = 200

--- a/features/app/index.ts
+++ b/features/app/index.ts
@@ -13,7 +13,7 @@ axiosRetry(axiosClient, {
         return retryAfter
       }
       if (error.response.status === 429 && error.config.url?.includes(HYPOTHESIS_API_BASE_URL)) {
-        return retryCount * 1000 /** ms */
+        return retryCount * 2000 /** ms */
       }
     }
     return axiosRetry.exponentialDelay(retryCount)

--- a/features/ati/AtiExportAnnotations/index.tsx
+++ b/features/ati/AtiExportAnnotations/index.tsx
@@ -14,8 +14,6 @@ import {
 } from "carbon-components-react"
 import CopyToClipboard from "react-copy-to-clipboard"
 
-import { axiosClient } from "../../app"
-
 import { AtiTab } from "../../../constants/ati"
 import { HYPOTHESIS_PUBLIC_GROUP_ID } from "../../../constants/hypothesis"
 import { ALL_HYPOTHESIS_GROUPS_ID } from "./constants"
@@ -29,6 +27,11 @@ import useTask, {
 import { IManuscript } from "../../../types/dataverse"
 import { IHypothesisGroup } from "../../../types/hypothesis"
 import { getMessageFromError } from "../../../utils/httpRequestUtils"
+import {
+  deleteAnnotations,
+  exportAnnotations,
+  getAnnotations,
+} from "../../../utils/hypothesisUtils"
 
 import styles from "./AtiExportAnnotations.module.css"
 import formStyles from "../../../styles/Form.module.css"
@@ -70,16 +73,12 @@ const AtiExportAnnotations: FC<AtiExportAnnotationstProps> = ({
   useEffect(() => {
     let didCancel = false
     const getAnnotationsJson = async () => {
-      const { data } = await axiosClient.get(`/api/hypothesis/${datasetId}/download-annotations`, {
-        params: {
-          hypothesisGroup: HYPOTHESIS_PUBLIC_GROUP_ID,
-          isAdminAuthor: false,
-        },
-        headers: {
-          Accept: "application/json",
-        },
+      const annotations = await getAnnotations({
+        datasetId,
+        hypothesisGroup: HYPOTHESIS_PUBLIC_GROUP_ID,
+        isAdminDownloader: false,
       })
-      const jsonStrs = data.annotations.map((annotation: any) => JSON.stringify(annotation))
+      const jsonStrs = annotations.map((annotation: any) => JSON.stringify(annotation))
       const arrayStr = encodeURIComponent(`[${jsonStrs.join(",")}]`)
       if (!didCancel) {
         setAnnotationsJsonStr(arrayStr)
@@ -97,64 +96,55 @@ const AtiExportAnnotations: FC<AtiExportAnnotationstProps> = ({
   const onExportAnnotations: FormEventHandler<HTMLFormElement> = async (e) => {
     e.preventDefault()
     const target = e.target as typeof e.target & {
+      sourceUrl: { value: string }
       destinationUrl: { value: string }
       destinationHypothesisGroup: { value: string }
       sourceHypothesisGroup: { value: string }
       privateAnnotation: { checked: boolean }
     }
+    try {
+      if (
+        target.sourceUrl.value === target.destinationUrl.value &&
+        target.sourceHypothesisGroup.value === target.destinationHypothesisGroup.value
+      ) {
+        throw new Error(
+          "Source Hypothes.is group and Destination Hypothes.is group must be different."
+        )
+      }
 
-    exportTaskDispatch({ type: TaskActionType.START, payload: "Downloading annotations..." })
-    await axiosClient
-      .get(`/api/hypothesis/${datasetId}/download-annotations`, {
-        params: {
-          hypothesisGroup:
-            target.sourceHypothesisGroup.value === ALL_HYPOTHESIS_GROUPS_ID
-              ? ""
-              : target.sourceHypothesisGroup.value,
-          isAdminAuthor: false,
-        },
+      exportTaskDispatch({ type: TaskActionType.START, payload: "Exporting annotations..." })
+      const totalExported = await exportAnnotations({
+        datasetId,
+        sourceHypothesisGroup: target.sourceHypothesisGroup.value,
+        isAdminDownloader: false,
+        destinationUrl: target.destinationUrl.value,
+        destinationHypothesisGroup: target.destinationHypothesisGroup.value,
+        privateAnnotation: target.privateAnnotation.checked,
+        isAdminAuthor: false,
+        taskDispatch: exportTaskDispatch,
       })
-      .then(({ data }) => {
-        exportTaskDispatch({ type: TaskActionType.NEXT_STEP, payload: "Exporting annotations..." })
-        return axiosClient.post(
-          `/api/hypothesis/${datasetId}/export-annotations`,
-          JSON.stringify({
-            isAdminAuthor: false,
-            destinationUrl: target.destinationUrl.value,
-            annotations: data.annotations,
-            destinationHypothesisGroup: target.destinationHypothesisGroup.value,
-            privateAnnotation: target.privateAnnotation.checked,
-          }),
-          {
-            headers: {
-              "Content-Type": "application/json",
-            },
-          }
-        )
-      })
-      .then(({ data }) => {
-        const hypothesisUrl = `https://hyp.is/go?url=${target.destinationUrl.value}&group=${target.destinationHypothesisGroup.value}`
-        exportHypothesisUrl.current = hypothesisUrl
-        const payload = (
-          <span>
-            {`Exported ${data.totalExported} annotation(s). Your manuscript with annotation(s) can
+
+      const hypothesisUrl = `https://hyp.is/go?url=${target.destinationUrl.value}&group=${target.destinationHypothesisGroup.value}`
+      exportHypothesisUrl.current = hypothesisUrl
+      const payload = (
+        <span>
+          {`Exported ${totalExported} annotation(s). Your manuscript with annotation(s) can
             be accessed at your`}{" "}
-            <Link href={hypothesisUrl} size="md" target="_blank" rel="noopener noreferrer">
-              <span>
-                destination <abbr>URL</abbr>
-              </span>
-              .
-            </Link>
-          </span>
-        )
-        exportTaskDispatch({
-          type: TaskActionType.FINISH,
-          payload,
-        })
+          <Link href={hypothesisUrl} size="md" target="_blank" rel="noopener noreferrer">
+            <span>
+              destination <abbr>URL</abbr>
+            </span>
+            .
+          </Link>
+        </span>
+      )
+      exportTaskDispatch({
+        type: TaskActionType.FINISH,
+        payload,
       })
-      .catch((e) => {
-        exportTaskDispatch({ type: TaskActionType.FAIL, payload: getMessageFromError(e) })
-      })
+    } catch (e) {
+      exportTaskDispatch({ type: TaskActionType.FAIL, payload: getMessageFromError(e) })
+    }
   }
 
   const onDeleteAnnotations: FormEventHandler<HTMLFormElement> = async (e) => {
@@ -172,38 +162,27 @@ const AtiExportAnnotations: FC<AtiExportAnnotationstProps> = ({
 
   const handleDeleteAnnotations = async () => {
     closeDeleteAnnotationsModal()
-    deleteTaskDispatch({ type: TaskActionType.START, payload: "Downloading annotations..." })
-    await axiosClient
-      .get(`/api/hypothesis/${datasetId}/download-annotations`, {
-        params: {
-          hypothesisGroup: deleteAnnotationsHypothesisGroup,
-          isAdminAuthor: false,
-        },
+    try {
+      deleteTaskDispatch({ type: TaskActionType.START, payload: "Deleting annotations..." })
+      const annotations = await getAnnotations({
+        datasetId,
+        hypothesisGroup: deleteAnnotationsHypothesisGroup,
+        isAdminDownloader: false,
       })
-      .then(({ data }) => {
-        deleteTaskDispatch({
-          type: TaskActionType.NEXT_STEP,
-          payload: `Deleting ${data.annotations.length} annotation(s)...`,
-        })
-        return axiosClient.delete(`/api/hypothesis/${datasetId}/delete-annotations`, {
-          data: JSON.stringify({ annotations: data.annotations }),
-          params: {
-            isAdminAuthor: false,
-          },
-          headers: {
-            "Content-Type": "application/json",
-          },
-        })
+
+      const totalDeleted = await deleteAnnotations({
+        datasetId,
+        annotations,
+        isAdminAuthor: false,
+        taskDispatch: deleteTaskDispatch,
       })
-      .then(({ data }) => {
-        deleteTaskDispatch({
-          type: TaskActionType.FINISH,
-          payload: `Deleted ${data.totalDeleted} annotation(s) from ${manuscript.name}.`,
-        })
+      deleteTaskDispatch({
+        type: TaskActionType.FINISH,
+        payload: `Deleted ${totalDeleted} annotation(s) from ${manuscript.name}.`,
       })
-      .catch((e) => {
-        deleteTaskDispatch({ type: TaskActionType.FAIL, payload: getMessageFromError(e) })
-      })
+    } catch (e) {
+      deleteTaskDispatch({ type: TaskActionType.FAIL, payload: getMessageFromError(e) })
+    }
   }
 
   return (
@@ -276,11 +255,6 @@ const AtiExportAnnotations: FC<AtiExportAnnotationstProps> = ({
               labelText="Source Hypothes.is group"
               defaultValue={HYPOTHESIS_PUBLIC_GROUP_ID}
             >
-              <SelectItem
-                key={ALL_HYPOTHESIS_GROUPS_ID}
-                text={"All groups"}
-                value={ALL_HYPOTHESIS_GROUPS_ID}
-              />
               {hypothesisGroups.map((group) => (
                 <SelectItem
                   key={group.id}

--- a/features/ati/AtiManuscript/index.tsx
+++ b/features/ati/AtiManuscript/index.tsx
@@ -178,11 +178,9 @@ const AtiManuscript: FC<AtiManuscriptProps> = ({
               : "Creating ingest PDF"
           } from ${uploadManuscriptTaskState.manuscript?.name}...`,
         })
-        await axiosClient.put(`/api/arcore/${newManuscriptId}`, undefined, {
-          params: {
-            datasetId,
-            uploadAnnotations: uploadManuscriptTaskState.uploadAnnotations,
-          },
+        await axiosClient.put(`/api/arcore/${newManuscriptId}`, {
+          datasetId,
+          uploadAnnotations: uploadManuscriptTaskState.uploadAnnotations,
         })
         taskDispatch({
           type: TaskActionType.FINISH,

--- a/features/ati/AtiManuscript/index.tsx
+++ b/features/ati/AtiManuscript/index.tsx
@@ -159,6 +159,7 @@ const AtiManuscript: FC<AtiManuscriptProps> = ({
         if (uploadManuscriptTaskState.uploadAnnotations) {
           const deleteAnns = await getAnnotations({
             datasetId,
+            // TODO: maybe don't delete everything written by the user -- just in public group?
             hypothesisGroup: "",
             isAdminDownloader: false,
           })

--- a/features/ati/AtiManuscript/index.tsx
+++ b/features/ati/AtiManuscript/index.tsx
@@ -24,6 +24,7 @@ import { ManuscriptMimeType, ManuscriptFileExtension } from "../../../constants/
 import { IDatasource, IManuscript } from "../../../types/dataverse"
 import { getMimeType } from "../../../utils/fileUtils"
 import { getMessageFromError } from "../../../utils/httpRequestUtils"
+import { deleteAnnotations, getAnnotations } from "../../../utils/hypothesisUtils"
 
 import styles from "./AtiManuscript.module.css"
 import formStyles from "../../../styles/Form.module.css"
@@ -137,79 +138,60 @@ const AtiManuscript: FC<AtiManuscriptProps> = ({
     // closes the modal if click `continue`
     uploadManuscriptTaskDispatch({ type: UploadManuscriptActionType.TOGGLE_MODAL_VISIBILITY })
     if (uploadManuscriptTaskState.manuscript) {
-      const formData = new FormData()
-      formData.append("manuscript", uploadManuscriptTaskState.manuscript)
-      taskDispatch({
-        type: TaskActionType.START,
-        payload: `Uploading ${uploadManuscriptTaskState.manuscript.name}...`,
-      })
-      await axiosClient({
-        method: "POST",
-        url: `/api/datasets/${datasetId}/manuscript`,
-        data: formData,
-        headers: {
-          "Content-Type": "multipart/form-data",
-        },
-      })
-        .then(async ({ data }) => {
-          const newManuscriptId = data.data.files[0].dataFile.id
-          const deleteAnnotationsPromise = uploadManuscriptTaskState.uploadAnnotations
-            ? axiosClient({
-                method: "GET",
-                url: `/api/hypothesis/${datasetId}/download-annotations`,
-                params: {
-                  hypothesisGroup: "",
-                  isAdminAuthor: false,
-                },
-              }).then(({ data }) => {
-                if (data.total > 0) {
-                  taskDispatch({
-                    type: TaskActionType.NEXT_STEP,
-                    payload: `Deleting current annotation(s) from Hypothes.is server...`,
-                  })
-                  return axiosClient({
-                    method: "DELETE",
-                    url: `/api/hypothesis/${datasetId}/delete-annotations`,
-                    data: JSON.stringify({ annotations: data.annotations }),
-                    params: {
-                      isAdminAuthor: false,
-                    },
-                    headers: {
-                      "Content-Type": "application/json",
-                    },
-                  })
-                }
-              })
-            : Promise.resolve("Skip!")
-          return await deleteAnnotationsPromise.then(() => {
-            taskDispatch({
-              type: TaskActionType.NEXT_STEP,
-              payload: `${
-                uploadManuscriptTaskState.uploadAnnotations
-                  ? "Extracting annotations"
-                  : "Creating ingest PDF"
-              } from ${uploadManuscriptTaskState.manuscript?.name}...`,
-            })
-            return axiosClient({
-              method: "PUT",
-              url: `/api/arcore/${newManuscriptId}`,
-              params: {
-                datasetId: datasetId,
-                uploadAnnotations: uploadManuscriptTaskState.uploadAnnotations,
-              },
-            })
+      try {
+        const formData = new FormData()
+        formData.append("manuscript", uploadManuscriptTaskState.manuscript)
+        taskDispatch({
+          type: TaskActionType.START,
+          payload: `Uploading ${uploadManuscriptTaskState.manuscript.name}...`,
+        })
+        const uploadManuscriptResponse = await axiosClient.post(
+          `/api/datasets/${datasetId}/manuscript`,
+          formData,
+          {
+            headers: {
+              "Content-Type": "multipart/form-data",
+            },
+          }
+        )
+        //TODO BETTER RESPONSE
+        const newManuscriptId = uploadManuscriptResponse.data.data.files[0].dataFile.id
+        if (uploadManuscriptTaskState.uploadAnnotations) {
+          const deleteAnns = await getAnnotations({
+            datasetId,
+            hypothesisGroup: "",
+            isAdminDownloader: false,
           })
+          if (deleteAnns.length > 0) {
+            await deleteAnnotations({
+              datasetId,
+              annotations: deleteAnns,
+              isAdminAuthor: false,
+            })
+          }
+        }
+        taskDispatch({
+          type: TaskActionType.NEXT_STEP,
+          payload: `${
+            uploadManuscriptTaskState.uploadAnnotations
+              ? "Extracting annotations"
+              : "Creating ingest PDF"
+          } from ${uploadManuscriptTaskState.manuscript?.name}...`,
         })
-        .then(() => {
-          taskDispatch({
-            type: TaskActionType.FINISH,
-            payload: `Uploaded ${uploadManuscriptTaskState.manuscript?.name}.`,
-          })
-          router.reload()
+        await axiosClient.put(`/api/arcore/${newManuscriptId}`, undefined, {
+          params: {
+            datasetId,
+            uploadAnnotations: uploadManuscriptTaskState.uploadAnnotations,
+          },
         })
-        .catch((error) => {
-          taskDispatch({ type: TaskActionType.FAIL, payload: getMessageFromError(error) })
+        taskDispatch({
+          type: TaskActionType.FINISH,
+          payload: `Uploaded ${uploadManuscriptTaskState.manuscript?.name}.`,
         })
+        router.reload()
+      } catch (e) {
+        taskDispatch({ type: TaskActionType.FAIL, payload: getMessageFromError(e) })
+      }
     } else {
       taskDispatch({ type: TaskActionType.FAIL, payload: "Please upload a manuscript file." })
     }

--- a/features/ati/AtiSummary/index.tsx
+++ b/features/ati/AtiSummary/index.tsx
@@ -10,6 +10,8 @@ import {
 import { Launch16 } from "@carbon/icons-react"
 import { useRouter } from "next/router"
 
+import { axiosClient } from "../../app"
+
 import { AtiTab } from "../../../constants/ati"
 import { PUBLICATION_STATUSES_COLOR } from "../../../constants/dataverse"
 import { HYPOTHESIS_PUBLIC_GROUP_ID } from "../../../constants/hypothesis"
@@ -86,7 +88,7 @@ const AtiSummary: FC<AtiSummaryProps> = ({
         privateAnnotation: false,
       })
 
-      //await axiosClient.post(`/api/datasets/${id}/submit-for-review`)
+      await axiosClient.post(`/api/datasets/${id}/submit-for-review`)
       taskDispatch({ type: TaskActionType.FINISH, payload: `Submitted ${title} for review.` })
       router.reload()
     } catch (e) {

--- a/features/ati/NewAtiProjectForm/index.tsx
+++ b/features/ati/NewAtiProjectForm/index.tsx
@@ -158,7 +158,7 @@ const NewAtiProjectForm: FC<NewAtiProjectFormProps> = ({
         return axiosClient({
           method: "PUT",
           url: `/api/arcore/${manuscriptId}`,
-          params: {
+          data: {
             datasetId: selectedDataset?.id,
             uploadAnnotations: true,
           },

--- a/pages/api/arcore/[id]/index.ts
+++ b/pages/api/arcore/[id]/index.ts
@@ -17,70 +17,63 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       const { id } = req.query
       const { datasetId, uploadAnnotations } = req.body
       const { dataverseApiToken, hypothesisApiToken } = session
-      const createPdfAnn = axiosClient({
-        method: "PUT",
-        url: `${process.env.ARCORE_SERVER_URL}/api/documents/${id}`,
-        headers: {
-          [DATAVERSE_HEADER_NAME]: dataverseApiToken,
-          [REQUEST_DESC_HEADER_NAME]: `Extracting annotations from source manuscript ${id}`,
-        },
-      })
-      await createPdfAnn
-        .then(() => {
-          return axiosClient({
-            method: "GET",
-            url: `${process.env.ARCORE_SERVER_URL}/api/documents/${id}/ann`,
-            headers: {
-              [DATAVERSE_HEADER_NAME]: dataverseApiToken,
-              [REQUEST_DESC_HEADER_NAME]: `Getting annotations from source manuscript ${id}`,
-            },
-          })
+      try {
+        await axiosClient.put(`${process.env.ARCORE_SERVER_URL}/api/documents/${id}`, undefined, {
+          headers: {
+            [DATAVERSE_HEADER_NAME]: dataverseApiToken,
+            [REQUEST_DESC_HEADER_NAME]: `Creating ingest PDF and extracting annotations from source manuscript ${id}`,
+          },
         })
-        .then(({ data }) => {
-          if (uploadAnnotations) {
-            //Uploading new file, send annotations to hypothes.is server
-            const uri = `${process.env.NEXTAUTH_URL}/ati/${datasetId}/${AtiTab.manuscript.id}`
-            const batches = range(0, data.length - 1, REQUEST_BATCH_SIZE)
-            batches.reduce((promise, start) => {
-              return promise.then(() => {
-                const sendAnns = data
-                  .slice(start, start + REQUEST_BATCH_SIZE)
-                  .map((annotation: any) => {
-                    annotation.target.forEach((element: any) => {
-                      element.source = uri
-                    })
-                    return axiosClient({
-                      method: "POST",
-                      url: `${process.env.HYPOTHESIS_SERVER_URL}/api/annotations`,
-                      data: JSON.stringify({
-                        uri: uri,
-                        document: annotation.document,
-                        text: annotation.text,
-                        target: annotation.target,
-                      }),
+        if (uploadAnnotations) {
+          const anns = await axiosClient.get(
+            `${process.env.ARCORE_SERVER_URL}/api/documents/${id}/ann`,
+            {
+              headers: {
+                [DATAVERSE_HEADER_NAME]: dataverseApiToken,
+                [REQUEST_DESC_HEADER_NAME]: `Getting annotations from source manuscript ${id}`,
+              },
+            }
+          )
+          const uri = `${process.env.NEXTAUTH_URL}/ati/${datasetId}/${AtiTab.manuscript.id}`
+          const batches = range(0, anns.data.length - 1, REQUEST_BATCH_SIZE)
+          await batches.reduce((promise, start) => {
+            return promise.then(() => {
+              const sendAnns = anns.data
+                .slice(start, start + REQUEST_BATCH_SIZE)
+                .map((annotation: any) => {
+                  annotation.target.forEach((element: any) => {
+                    element.source = uri
+                  })
+                  return axiosClient.post(
+                    `${process.env.HYPOTHESIS_SERVER_URL}/api/annotations`,
+                    JSON.stringify({
+                      uri: uri,
+                      document: annotation.document,
+                      text: annotation.text,
+                      target: annotation.target,
+                    }),
+                    {
                       headers: {
                         Authorization: `Bearer ${hypothesisApiToken}`,
                         "Content-type": "application/json",
                         [REQUEST_DESC_HEADER_NAME]: `Sending annotations from source manuscript ${id} to Hypothes.is server`,
                       },
-                    })
-                  })
-                return Promise.all(sendAnns)
-              })
-            }, Promise.resolve<any[]>([]))
-          }
-        })
-        .then(() => {
-          res.status(200).json({ manuscriptId: id })
-        })
-        .catch((e) => {
-          const { status, message } = getResponseFromError(
-            e,
-            `Extracting annotations from source manuscript ${id} and sending annotations to Hypothes.is server`
-          )
-          console.error(status, message)
-          res.status(status).json({ message })
-        })
+                    }
+                  )
+                })
+              return Promise.all(sendAnns)
+            })
+          }, Promise.resolve<any[]>([]))
+        }
+        res.status(200).json({ manuscriptId: id })
+      } catch (e) {
+        const { status, message } = getResponseFromError(
+          e,
+          `Extracting annotations from source manuscript ${id} and sending annotations to Hypothes.is server`
+        )
+        console.error(status, message)
+        res.status(status).json({ message })
+      }
     } else {
       res.status(401).json({ message: "Unauthorized. Please login. " })
     }

--- a/pages/api/arcore/[id]/index.ts
+++ b/pages/api/arcore/[id]/index.ts
@@ -11,11 +11,11 @@ import { range } from "../../../../utils/arrayUtils"
 import { getResponseFromError } from "../../../../utils/httpRequestUtils"
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse): Promise<void> {
-  const { datasetId, uploadAnnotations } = req.query
   if (req.method === "PUT") {
     const session = await getSession({ req })
     if (session) {
       const { id } = req.query
+      const { datasetId, uploadAnnotations } = req.body
       const { dataverseApiToken, hypothesisApiToken } = session
       const createPdfAnn = axiosClient({
         method: "PUT",
@@ -37,7 +37,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
           })
         })
         .then(({ data }) => {
-          if (uploadAnnotations === "true") {
+          if (uploadAnnotations) {
             //Uploading new file, send annotations to hypothes.is server
             const uri = `${process.env.NEXTAUTH_URL}/ati/${datasetId}/${AtiTab.manuscript.id}`
             const batches = range(0, data.length - 1, REQUEST_BATCH_SIZE)

--- a/pages/api/datasets/[id]/manuscript/index.ts
+++ b/pages/api/datasets/[id]/manuscript/index.ts
@@ -63,6 +63,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
                 [REQUEST_DESC_HEADER_NAME]: requestDesc,
               },
             })
+            //TODO more specific response, manu id
             res.status(status).json(data)
             resolve()
           } catch (e) {

--- a/pages/api/hypothesis/[id]/delete-annotations.ts
+++ b/pages/api/hypothesis/[id]/delete-annotations.ts
@@ -4,8 +4,6 @@ import { getSession } from "next-auth/client"
 import { axiosClient } from "../../../../features/app"
 
 import { REQUEST_DESC_HEADER_NAME } from "../../../../constants/http"
-import { REQUEST_BATCH_SIZE } from "../../../../constants/hypothesis"
-import { range } from "../../../../utils/arrayUtils"
 import { getResponseFromError } from "../../../../utils/httpRequestUtils"
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse): Promise<void> {
@@ -15,14 +13,14 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       headers: { Authorization: `Bearer ${process.env.ADMIN_HYPOTHESIS_API_TOKEN}` },
     })
     if (session) {
-      const { id, isAdminAuthor } = req.query
-      const { annotations } = req.body
+      const { id } = req.query
+      const { annotations, isAdminAuthor } = req.body
       const requestDesc = `Deleting annotations from data project ${id}`
       const { hypothesisApiToken: userHypothesisApiToken, hypothesisUserId: userHypothesisUserId } =
         session
       let hypothesisApiToken = userHypothesisApiToken
       let hypothesisUserId = userHypothesisUserId
-      if (isAdminAuthor === "true") {
+      if (isAdminAuthor) {
         hypothesisApiToken = process.env.ADMIN_HYPOTHESIS_API_TOKEN
         hypothesisUserId = data.userid
       }
@@ -30,29 +28,20 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         const deletableAnnotations = annotations.filter((annotation: any) =>
           annotation.permissions.delete.includes(hypothesisUserId)
         )
-
-        const batches = range(0, deletableAnnotations.length - 1, REQUEST_BATCH_SIZE)
-        for (const start of batches) {
-          const batchedDeleteAnns = deletableAnnotations
-            .slice(start, start + REQUEST_BATCH_SIZE)
-            .map((annotation: any) => {
-              return axiosClient.delete(
-                `${process.env.HYPOTHESIS_SERVER_URL}/api/annotations/${annotation.id}`,
-                {
-                  headers: {
-                    Authorization: `Bearer ${hypothesisApiToken}`,
-                    [REQUEST_DESC_HEADER_NAME]: requestDesc,
-                  },
-                }
-              )
-            })
-          await Promise.all(batchedDeleteAnns)
-        }
+        const deleteAnns = deletableAnnotations.map((annotation: any) => {
+          return axiosClient.delete(
+            `${process.env.HYPOTHESIS_SERVER_URL}/api/annotations/${annotation.id}`,
+            {
+              headers: {
+                Authorization: `Bearer ${hypothesisApiToken}`,
+                [REQUEST_DESC_HEADER_NAME]: requestDesc,
+              },
+            }
+          )
+        })
+        await Promise.all(deleteAnns)
         res.status(200).json({
-          totalDeleted:
-            deletableAnnotations.length === annotations.length
-              ? annotations.length
-              : `${deletableAnnotations.length}/${annotations.length}`,
+          total: deletableAnnotations.length,
         })
       } catch (e) {
         const { status, message } = getResponseFromError(e, requestDesc)

--- a/pages/api/hypothesis/[id]/export-annotations.ts
+++ b/pages/api/hypothesis/[id]/export-annotations.ts
@@ -22,7 +22,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         privateAnnotation,
         isAdminAuthor,
       } = req.body
-      const requestDesc = `Exporting annotations to ${destinationUrl}...`
+      const requestDesc = `Exporting annotations to ${destinationUrl}`
       const uri = `${process.env.NEXTAUTH_URL}/ati/${id}/${AtiTab.manuscript.id}`
       const searchEndpoint = `${process.env.HYPOTHESIS_SERVER_URL}/api/search`
       const { hypothesisApiToken } = session
@@ -39,7 +39,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
               isAdminDownloader ? process.env.ADMIN_HYPOTHESIS_API_TOKEN : hypothesisApiToken
             }`,
             Accept: "application/json",
-            [REQUEST_DESC_HEADER_NAME]: `Downloading annotations at offset ${offset}...`,
+            [REQUEST_DESC_HEADER_NAME]: `Downloading annotations at offset ${offset}`,
           },
         })
         const exactMatches = data.rows.filter((annotation: any) => annotation.uri === uri)

--- a/pages/api/hypothesis/[id]/export-annotations.ts
+++ b/pages/api/hypothesis/[id]/export-annotations.ts
@@ -3,63 +3,79 @@ import { getSession } from "next-auth/client"
 
 import { axiosClient } from "../../../../features/app"
 
+import { AtiTab } from "../../../../constants/ati"
 import { REQUEST_DESC_HEADER_NAME } from "../../../../constants/http"
-import { REQUEST_BATCH_SIZE } from "../../../../constants/hypothesis"
-import { range } from "../../../../utils/arrayUtils"
 import { getResponseFromError } from "../../../../utils/httpRequestUtils"
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse): Promise<void> {
   if (req.method === "POST") {
     const session = await getSession({ req })
     if (session) {
+      const { id } = req.query
       const {
-        destinationUrl: url,
-        isAdminAuthor,
-        annotations,
+        sourceHypothesisGroup,
+        isAdminDownloader,
+        offset,
+        limit,
+        destinationUrl,
         destinationHypothesisGroup,
         privateAnnotation,
+        isAdminAuthor,
       } = req.body
-      const requestDesc = `Exporting annotations to ${url}`
+      const requestDesc = `Exporting annotations to ${destinationUrl}...`
+      const uri = `${process.env.NEXTAUTH_URL}/ati/${id}/${AtiTab.manuscript.id}`
+      const searchEndpoint = `${process.env.HYPOTHESIS_SERVER_URL}/api/search`
       const { hypothesisApiToken } = session
       try {
-        const batches = range(0, annotations.length - 1, REQUEST_BATCH_SIZE)
-        for (const start of batches) {
-          const copyAnns = annotations
-            .slice(start, start + REQUEST_BATCH_SIZE)
-            .map((annotation: any) => {
-              annotation.target.forEach((element: any) => {
-                element.source = url
-              })
-              let newReadPermission = annotation.permissions.read
-              if (!privateAnnotation) {
-                newReadPermission = [`group:${destinationHypothesisGroup}`]
-              }
-              return axiosClient({
-                method: "POST",
-                url: `${process.env.HYPOTHESIS_SERVER_URL}/api/annotations`,
-                data: JSON.stringify({
-                  uri: url,
-                  //document
-                  text: annotation.text,
-                  tags: annotation.tags,
-                  group: destinationHypothesisGroup,
-                  permissions: { read: newReadPermission },
-                  target: annotation.target,
-                  //references
-                }),
-                headers: {
-                  Authorization: `Bearer ${
-                    isAdminAuthor ? process.env.ADMIN_HYPOTHESIS_API_TOKEN : hypothesisApiToken
-                  }`,
-                  "Content-type": "application/json",
-                  [REQUEST_DESC_HEADER_NAME]: requestDesc,
-                },
-              })
-            })
-          await Promise.all(copyAnns)
-        }
+        const { data } = await axiosClient.get(searchEndpoint, {
+          params: {
+            limit,
+            uri,
+            offset,
+            group: sourceHypothesisGroup,
+          },
+          headers: {
+            Authorization: `Bearer ${
+              isAdminDownloader ? process.env.ADMIN_HYPOTHESIS_API_TOKEN : hypothesisApiToken
+            }`,
+            Accept: "application/json",
+            [REQUEST_DESC_HEADER_NAME]: `Downloading annotations at offset ${offset}...`,
+          },
+        })
+        const exactMatches = data.rows.filter((annotation: any) => annotation.uri === uri)
+        const copyAnns = exactMatches.map((annotation: any) => {
+          annotation.target.forEach((element: any) => {
+            element.source = destinationUrl
+          })
+          let newReadPermission = annotation.permissions.read
+          if (!privateAnnotation) {
+            newReadPermission = [`group:${destinationHypothesisGroup}`]
+          }
+          return axiosClient({
+            method: "POST",
+            url: `${process.env.HYPOTHESIS_SERVER_URL}/api/annotations`,
+            data: JSON.stringify({
+              uri: destinationUrl,
+              //document
+              text: annotation.text,
+              tags: annotation.tags,
+              group: destinationHypothesisGroup,
+              permissions: { read: newReadPermission },
+              target: annotation.target,
+              //references
+            }),
+            headers: {
+              Authorization: `Bearer ${
+                isAdminAuthor ? process.env.ADMIN_HYPOTHESIS_API_TOKEN : hypothesisApiToken
+              }`,
+              "Content-type": "application/json",
+              [REQUEST_DESC_HEADER_NAME]: requestDesc,
+            },
+          })
+        })
+        await Promise.all(copyAnns)
         res.status(200).json({
-          totalExported: annotations.length,
+          total: exactMatches.length,
         })
       } catch (e) {
         const { status, message } = getResponseFromError(e, requestDesc)

--- a/pages/api/hypothesis/[id]/export-annotations.ts
+++ b/pages/api/hypothesis/[id]/export-annotations.ts
@@ -1,10 +1,11 @@
-import { AxiosPromise } from "axios"
 import { NextApiRequest, NextApiResponse } from "next"
 import { getSession } from "next-auth/client"
 
 import { axiosClient } from "../../../../features/app"
 
 import { REQUEST_DESC_HEADER_NAME } from "../../../../constants/http"
+import { REQUEST_BATCH_SIZE } from "../../../../constants/hypothesis"
+import { range } from "../../../../utils/arrayUtils"
 import { getResponseFromError } from "../../../../utils/httpRequestUtils"
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse): Promise<void> {
@@ -21,37 +22,42 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       const requestDesc = `Exporting annotations to ${url}`
       const { hypothesisApiToken } = session
       try {
-        const copyAnns: AxiosPromise<any>[] = annotations.map((annotation: any) => {
-          annotation.target.forEach((element: any) => {
-            element.source = url
-          })
-          let newReadPermission = annotation.permissions.read
-          if (!privateAnnotation) {
-            newReadPermission = [`group:${destinationHypothesisGroup}`]
-          }
-          return axiosClient({
-            method: "POST",
-            url: `${process.env.HYPOTHESIS_SERVER_URL}/api/annotations`,
-            data: JSON.stringify({
-              uri: url,
-              //document
-              text: annotation.text,
-              tags: annotation.tags,
-              group: destinationHypothesisGroup,
-              permissions: { read: newReadPermission },
-              target: annotation.target,
-              //references
-            }),
-            headers: {
-              Authorization: `Bearer ${
-                isAdminAuthor ? process.env.ADMIN_HYPOTHESIS_API_TOKEN : hypothesisApiToken
-              }`,
-              "Content-type": "application/json",
-              [REQUEST_DESC_HEADER_NAME]: requestDesc,
-            },
-          })
-        })
-        await Promise.all(copyAnns)
+        const batches = range(0, annotations.length - 1, REQUEST_BATCH_SIZE)
+        for (const start of batches) {
+          const copyAnns = annotations
+            .slice(start, start + REQUEST_BATCH_SIZE)
+            .map((annotation: any) => {
+              annotation.target.forEach((element: any) => {
+                element.source = url
+              })
+              let newReadPermission = annotation.permissions.read
+              if (!privateAnnotation) {
+                newReadPermission = [`group:${destinationHypothesisGroup}`]
+              }
+              return axiosClient({
+                method: "POST",
+                url: `${process.env.HYPOTHESIS_SERVER_URL}/api/annotations`,
+                data: JSON.stringify({
+                  uri: url,
+                  //document
+                  text: annotation.text,
+                  tags: annotation.tags,
+                  group: destinationHypothesisGroup,
+                  permissions: { read: newReadPermission },
+                  target: annotation.target,
+                  //references
+                }),
+                headers: {
+                  Authorization: `Bearer ${
+                    isAdminAuthor ? process.env.ADMIN_HYPOTHESIS_API_TOKEN : hypothesisApiToken
+                  }`,
+                  "Content-type": "application/json",
+                  [REQUEST_DESC_HEADER_NAME]: requestDesc,
+                },
+              })
+            })
+          await Promise.all(copyAnns)
+        }
         res.status(200).json({
           totalExported: annotations.length,
         })

--- a/utils/hypothesisUtils.ts
+++ b/utils/hypothesisUtils.ts
@@ -1,0 +1,161 @@
+import { Dispatch } from "react"
+import { AxiosResponse } from "axios"
+
+import { axiosClient } from "../features/app"
+import { ITaskAction, TaskActionType } from "../hooks/useTask/state"
+
+import { ANNOTATIONS_MAX_LIMIT, REQUEST_BATCH_SIZE } from "../constants/hypothesis"
+import { range } from "./arrayUtils"
+
+interface GetAnnotationsArgs {
+  datasetId: string
+  hypothesisGroup: string
+  isAdminDownloader: boolean
+}
+export async function getTotalAnnotations(args: GetAnnotationsArgs): Promise<number> {
+  const { datasetId, hypothesisGroup, isAdminDownloader } = args
+  const { data: totalAnns } = await axiosClient.get<{ total: number }>(
+    `/api/hypothesis/${datasetId}/total-annotations`,
+    {
+      params: {
+        hypothesisGroup,
+        isAdminDownloader,
+      },
+      headers: {
+        Accept: "application/json",
+      },
+    }
+  )
+  return totalAnns.total
+}
+
+export async function getAnnotations(args: GetAnnotationsArgs): Promise<any[]> {
+  const { datasetId, hypothesisGroup, isAdminDownloader } = args
+  const total = await getTotalAnnotations(args)
+
+  const offsets = range(0, total - 1, ANNOTATIONS_MAX_LIMIT)
+  const batches = range(0, offsets.length - 1, REQUEST_BATCH_SIZE)
+  const responses = await batches.reduce((promise, start) => {
+    return promise.then((acc) => {
+      const downloadAnns = offsets.slice(start, start + REQUEST_BATCH_SIZE).map((offset) => {
+        return axiosClient.get(`/api/hypothesis/${datasetId}/download-annotations`, {
+          params: {
+            offset,
+            hypothesisGroup,
+            isAdminDownloader,
+            limit: ANNOTATIONS_MAX_LIMIT,
+          },
+          headers: {
+            Accept: "application/json",
+          },
+        })
+      })
+      return Promise.all(downloadAnns).then((resp) => acc.concat(resp))
+    })
+  }, Promise.resolve<AxiosResponse<any>[]>([]))
+
+  // 2d array
+  const allRows = responses.map(({ data }) => data.rows)
+  const annotations = [].concat(...allRows) as any[]
+  return annotations
+}
+
+interface DeleteAnnotationsArgs {
+  datasetId: string
+  annotations: any[]
+  isAdminAuthor: boolean
+  taskDispatch?: Dispatch<ITaskAction>
+}
+export async function deleteAnnotations(args: DeleteAnnotationsArgs): Promise<number> {
+  const { datasetId, annotations, isAdminAuthor, taskDispatch } = args
+  let totalDeleted = 0
+  const anns = annotations.map((ann: any) => {
+    return {
+      id: ann.id,
+      permissions: { delete: ann.permissions.delete },
+    }
+  })
+  const offsets = range(0, annotations.length - 1, REQUEST_BATCH_SIZE)
+  for (const offset of offsets) {
+    const toDeleteAnns = anns.slice(offset, offset + REQUEST_BATCH_SIZE)
+    if (taskDispatch) {
+      taskDispatch({
+        type: TaskActionType.NEXT_STEP,
+        payload: `Processing ${offset + 1} to ${Math.min(
+          offset + REQUEST_BATCH_SIZE,
+          annotations.length
+        )} of ${annotations.length} annotations...`,
+      })
+    }
+    const response = await axiosClient.delete<{ total: number }>(
+      `/api/hypothesis/${datasetId}/delete-annotations`,
+      {
+        data: JSON.stringify({ isAdminAuthor, annotations: toDeleteAnns }),
+        headers: {
+          "Content-Type": "application/json",
+        },
+      }
+    )
+    totalDeleted += response.data.total
+  }
+  return totalDeleted
+}
+
+interface ExportAnnotationsArgs {
+  datasetId: string
+  sourceHypothesisGroup: string
+  isAdminDownloader: boolean
+  destinationUrl: string
+  destinationHypothesisGroup: string
+  privateAnnotation: boolean
+  isAdminAuthor: boolean
+  taskDispatch: Dispatch<ITaskAction>
+}
+export async function exportAnnotations(args: ExportAnnotationsArgs): Promise<number> {
+  const {
+    datasetId,
+    sourceHypothesisGroup,
+    isAdminDownloader,
+    destinationUrl,
+    destinationHypothesisGroup,
+    privateAnnotation,
+    isAdminAuthor,
+    taskDispatch,
+  } = args
+  const total = await getTotalAnnotations({
+    datasetId,
+    isAdminDownloader,
+    hypothesisGroup: sourceHypothesisGroup,
+  })
+  let totalDeleted = 0
+  const offsets = range(0, total - 1, REQUEST_BATCH_SIZE)
+  for (const offset of offsets) {
+    taskDispatch({
+      type: TaskActionType.NEXT_STEP,
+      payload: `Processing ${offset + 1} to ${Math.min(
+        offset + REQUEST_BATCH_SIZE,
+        total
+      )} of ${total} annotations...`,
+    })
+    const response = await axiosClient.post<{ total: number }>(
+      `/api/hypothesis/${datasetId}/export-annotations`,
+      JSON.stringify({
+        sourceHypothesisGroup,
+        isAdminDownloader,
+        offset,
+        destinationUrl,
+        destinationHypothesisGroup,
+        isAdminAuthor,
+        privateAnnotation,
+        limit: REQUEST_BATCH_SIZE,
+      }),
+      {
+        headers: {
+          "Content-Type": "application/json",
+        },
+      }
+    )
+    totalDeleted += response.data.total
+  }
+  return totalDeleted
+}


### PR DESCRIPTION
Previously, requests such as delete annotations or create annotations are done concurrently, which causes AnnoRep to hit a ~40reqs/sec limit and error out.

Now, delete or create annotations are done in sequential order. AnnoRep will send a batch of 30 requests concurrently (with retry logic #80 for each request ), and then wait until those requests finish in order to send the next batch of 30 requests. If a batch of requests finishes before a duration of 1 sec, then the next batch may result in a 429 error and enter the retry logic. The retry logic will lower the user's request rate until the batch finishes (as time passes the user's request rate gets lower). Suppose the first 30 requests finish before a duration of 1 sec, then the next 30 requests will possibly enter the retry logic and wait for 2s until retrying (which is good enough for them to finish without hitting the limit).

cc @adam3smith I'll merge this after doing more tests from a file with more annotations.