### PR TITLE
fix/ati-tab-stories

### DIFF
--- a/features/ati/AtiTab/AtiTab.stories.tsx
+++ b/features/ati/AtiTab/AtiTab.stories.tsx
@@ -10,7 +10,16 @@ export default {
 const Template: Story<AtiTabProps> = (args) => <AtiTab {...args} />
 
 const args = {
-  isLoggedIn: true,
+  user: {
+    dataverse: {
+      name: "User name @ QDR",
+      link: "test.com",
+    },
+    hypothesis: {
+      name: "User name @ Hypothes.is",
+      link: "test.com",
+    },
+  },
   dataset: {
     id: "dataset-id",
     doi: "doi",


### PR DESCRIPTION
`AtiTab` component expects an `IAnnoRepUser` prop in place of the older `isLoggedIn` prop. Created a fake user for the stories of this component.