### PR TITLE
feature/add-qdr-ati-info-to-annotatons

### DIFF
--- a/constants/ati.ts
+++ b/constants/ati.ts
@@ -13,3 +13,6 @@ export const tabs = [
   AtiTab.exportAnnotations.id,
   AtiTab.settings.id,
 ]
+
+export const ATI_HEADER_HTML =
+  '<a href="https://qdr.syr.edu/ati"><img src="https://qdr.syr.edu/drupal_data/public/ati_banner_long.png" align="left"/></a><br>'

--- a/features/ati/AtiExportAnnotations/AtiExportAnnotations.stories.tsx
+++ b/features/ati/AtiExportAnnotations/AtiExportAnnotations.stories.tsx
@@ -11,7 +11,11 @@ const Template: Story<AtiExportAnnotationstProps> = (args) => <AtiExportAnnotati
 
 export const Default = Template.bind({})
 Default.args = {
-  datasetId: "dataset-id",
+  dataset: {
+    id: "dataset-id",
+    doi: "dataset-doi",
+    title: "Dataset title",
+  },
   manuscript: {
     id: "manuscript-id",
     name: "manuscript",

--- a/features/ati/AtiExportAnnotations/index.tsx
+++ b/features/ati/AtiExportAnnotations/index.tsx
@@ -46,6 +46,8 @@ export interface AtiExportAnnotationstProps {
   manuscript: IManuscript
   /** The list of hypothes.is groups */
   hypothesisGroups: IHypothesisGroup[]
+  /** Can the exported annotations be prefixed with QDR info */
+  canAddQdrInfo: boolean
 }
 
 const AtiExportAnnotations: FC<AtiExportAnnotationstProps> = ({
@@ -53,6 +55,7 @@ const AtiExportAnnotations: FC<AtiExportAnnotationstProps> = ({
   datasetId,
   manuscript,
   hypothesisGroups,
+  canAddQdrInfo,
 }) => {
   const exportHypothesisUrl = useRef("")
   const { state: exportTaskState, dispatch: exportTaskDispatch } = useTask({
@@ -101,6 +104,7 @@ const AtiExportAnnotations: FC<AtiExportAnnotationstProps> = ({
       destinationHypothesisGroup: { value: string }
       sourceHypothesisGroup: { value: string }
       privateAnnotation: { checked: boolean }
+      addQdrInfo: { checked: boolean }
     }
     try {
       if (
@@ -121,6 +125,7 @@ const AtiExportAnnotations: FC<AtiExportAnnotationstProps> = ({
         destinationHypothesisGroup: target.destinationHypothesisGroup.value,
         privateAnnotation: target.privateAnnotation.checked,
         isAdminAuthor: false,
+        addQdrInfo: target.addQdrInfo.checked,
         taskDispatch: exportTaskDispatch,
       })
 
@@ -303,6 +308,17 @@ const AtiExportAnnotations: FC<AtiExportAnnotationstProps> = ({
               name="privateAnnotation"
             />
           </div>
+          {canAddQdrInfo && (
+            <div className={formStyles.item}>
+              <Toggle
+                id="toggle-add-qdr-info"
+                labelA="No"
+                labelB="Yes"
+                labelText="Add QDR information to annotations"
+                name="addQdrInfo"
+              />
+            </div>
+          )}
           <Button
             className={formStyles.submitBtn}
             type="submit"

--- a/features/ati/AtiExportAnnotations/index.tsx
+++ b/features/ati/AtiExportAnnotations/index.tsx
@@ -40,13 +40,13 @@ import layoutStyles from "../../components/Layout/Layout.module.css"
 export interface AtiExportAnnotationstProps {
   /** The canonical url of the app */
   appUrl: string
-  /** The dataset id of the ati project */
+  /** The dataset of the ati project */
   dataset: IDataset
   /** The manuscript for the ati project */
   manuscript: IManuscript
   /** The list of hypothes.is groups */
   hypothesisGroups: IHypothesisGroup[]
-  /** Can the exported annotations be prefixed with QDR info */
+  /** Can the exported annotations be prefixed with QDR info? */
   canAddQdrInfo: boolean
 }
 

--- a/features/ati/AtiSummary/index.tsx
+++ b/features/ati/AtiSummary/index.tsx
@@ -86,7 +86,6 @@ const AtiSummary: FC<AtiSummaryProps> = ({
         destinationHypothesisGroup: hypothesisAtiStagingGroupId,
         isAdminAuthor: true,
         privateAnnotation: false,
-        addQdrInfo: false,
       })
 
       await axiosClient.post(`/api/datasets/${id}/submit-for-review`)

--- a/features/ati/AtiSummary/index.tsx
+++ b/features/ati/AtiSummary/index.tsx
@@ -86,6 +86,7 @@ const AtiSummary: FC<AtiSummaryProps> = ({
         destinationHypothesisGroup: hypothesisAtiStagingGroupId,
         isAdminAuthor: true,
         privateAnnotation: false,
+        addQdrInfo: false,
       })
 
       await axiosClient.post(`/api/datasets/${id}/submit-for-review`)

--- a/pages/api/hypothesis/[id]/export-annotations.ts
+++ b/pages/api/hypothesis/[id]/export-annotations.ts
@@ -44,7 +44,6 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
           },
         })
         const exactMatches = data.rows.filter((annotation: any) => annotation.uri === uri)
-        //TODO: prefix each annotation with qdr info
         const copyAnns = exactMatches.map((annotation: any) => {
           annotation.target.forEach((element: any) => {
             element.source = destinationUrl

--- a/pages/api/hypothesis/[id]/export-annotations.ts
+++ b/pages/api/hypothesis/[id]/export-annotations.ts
@@ -3,7 +3,7 @@ import { getSession } from "next-auth/client"
 
 import { axiosClient } from "../../../../features/app"
 
-import { AtiTab } from "../../../../constants/ati"
+import { AtiTab, ATI_HEADER_HTML } from "../../../../constants/ati"
 import { REQUEST_DESC_HEADER_NAME } from "../../../../constants/http"
 import { getResponseFromError } from "../../../../utils/httpRequestUtils"
 
@@ -20,6 +20,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         destinationUrl,
         destinationHypothesisGroup,
         privateAnnotation,
+        addQdrInfo,
         isAdminAuthor,
       } = req.body
       const requestDesc = `Exporting annotations to ${destinationUrl}`
@@ -43,6 +44,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
           },
         })
         const exactMatches = data.rows.filter((annotation: any) => annotation.uri === uri)
+        //TODO: prefix each annotation with qdr info
         const copyAnns = exactMatches.map((annotation: any) => {
           annotation.target.forEach((element: any) => {
             element.source = destinationUrl
@@ -51,13 +53,17 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
           if (!privateAnnotation) {
             newReadPermission = [`group:${destinationHypothesisGroup}`]
           }
+          let newText = annotation.text
+          if (addQdrInfo) {
+            newText = `${ATI_HEADER_HTML}${annotation.text}`
+          }
           return axiosClient({
             method: "POST",
             url: `${process.env.HYPOTHESIS_SERVER_URL}/api/annotations`,
             data: JSON.stringify({
               uri: destinationUrl,
               //document
-              text: annotation.text,
+              text: newText,
               tags: annotation.tags,
               group: destinationHypothesisGroup,
               permissions: { read: newReadPermission },

--- a/pages/api/hypothesis/[id]/title-annotation.ts
+++ b/pages/api/hypothesis/[id]/title-annotation.ts
@@ -60,6 +60,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         const dataset = myDataResponse.data.data.items[0]
         const citationHtml = dataset.citationHtml
         const doiUrl = dataset.url
+        const isDraftState = dataset.is_draft_state
 
         const annotation = titleAnnResponse.data
         annotation.target.forEach((element: any) => {
@@ -74,7 +75,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
           JSON.stringify({
             uri: destinationUrl,
             document: annotation.document,
-            text: createInitialAnnotationText(citationHtml, doiUrl),
+            text: createInitialAnnotationText(citationHtml, doiUrl, isDraftState),
             target: annotation.target,
             group: destinationHypothesisGroup,
             permissions: { read: newReadPermission },

--- a/pages/api/hypothesis/[id]/title-annotation.ts
+++ b/pages/api/hypothesis/[id]/title-annotation.ts
@@ -1,0 +1,72 @@
+import { NextApiRequest, NextApiResponse } from "next"
+import { getSession } from "next-auth/client"
+
+import { axiosClient } from "../../../../features/app"
+
+import { REQUEST_DESC_HEADER_NAME } from "../../../../constants/http"
+import { getResponseFromError } from "../../../../utils/httpRequestUtils"
+import { DATAVERSE_HEADER_NAME } from "../../../../constants/dataverse"
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse): Promise<void> {
+  if (req.method === "POST") {
+    const session = await getSession({ req })
+    if (session) {
+      const { id } = req.query
+      const { destinationUrl, destinationHypothesisGroup, privateAnnotation, manuscriptId } =
+        req.body
+      const { dataverseApiToken, hypothesisApiToken, hypothesisUserId } = session
+      const requestDesc = `Getting the total number of annotations for data project ${id}`
+      try {
+        //get title ann
+        const titleAnnResponse = await axiosClient.get(
+          `${process.env.ARCORE_SERVER_URL}/api/documents/${manuscriptId}/titleann`,
+          {
+            headers: {
+              [DATAVERSE_HEADER_NAME]: dataverseApiToken,
+              [REQUEST_DESC_HEADER_NAME]: `Getting title annotation from source manuscript ${manuscriptId}`,
+            },
+          }
+        )
+        //send title ann
+        const annotation = titleAnnResponse.data
+        annotation.target.forEach((element: any) => {
+          element.source = destinationUrl
+        })
+        let newReadPermission = [hypothesisUserId]
+        if (!privateAnnotation) {
+          newReadPermission = [`group:${destinationHypothesisGroup}`]
+        }
+        await axiosClient.post(
+          `${process.env.HYPOTHESIS_SERVER_URL}/api/annotations`,
+          JSON.stringify({
+            uri: destinationUrl,
+            document: annotation.document,
+            //assume text already has the QDR header
+            text: annotation.text,
+            //tags: annotation.tags,
+            target: annotation.target,
+            group: destinationHypothesisGroup,
+            //TODO: need to test
+            permissions: { read: newReadPermission },
+          }),
+          {
+            headers: {
+              Authorization: `Bearer ${hypothesisApiToken}`,
+              "Content-type": "application/json",
+              [REQUEST_DESC_HEADER_NAME]: `Sending title annotation from source manuscript ${manuscriptId} to Hypothes.is server`,
+            },
+          }
+        )
+        res.status(200)
+      } catch (e) {
+        const { status, message } = getResponseFromError(e, requestDesc)
+        console.error(status, message)
+        res.status(status).json({ message })
+      }
+    } else {
+      res.status(401).json({ message: "Unauthorized! Please login." })
+    }
+  } else {
+    res.status(405).json({ message: `${req.method} method is not allowed.` })
+  }
+}

--- a/pages/api/hypothesis/[id]/title-annotation.ts
+++ b/pages/api/hypothesis/[id]/title-annotation.ts
@@ -1,33 +1,66 @@
 import { NextApiRequest, NextApiResponse } from "next"
 import { getSession } from "next-auth/client"
+import qs from "qs"
 
 import { axiosClient } from "../../../../features/app"
 
 import { REQUEST_DESC_HEADER_NAME } from "../../../../constants/http"
 import { getResponseFromError } from "../../../../utils/httpRequestUtils"
-import { DATAVERSE_HEADER_NAME } from "../../../../constants/dataverse"
+import {
+  DATASET_DV_TYPE,
+  DATAVERSE_HEADER_NAME,
+  PUBLICATION_STATUSES,
+} from "../../../../constants/dataverse"
+import { createInitialAnnotationText } from "../../../../utils/hypothesisUtils"
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse): Promise<void> {
   if (req.method === "POST") {
     const session = await getSession({ req })
     if (session) {
       const { id } = req.query
-      const { destinationUrl, destinationHypothesisGroup, privateAnnotation, manuscriptId } =
-        req.body
+      const {
+        destinationUrl,
+        destinationHypothesisGroup,
+        privateAnnotation,
+        manuscriptId,
+        datasetDoi,
+      } = req.body
       const { dataverseApiToken, hypothesisApiToken, hypothesisUserId } = session
-      const requestDesc = `Getting the total number of annotations for data project ${id}`
+      const requestDesc = `Creating ATI annotation for data project ${id}`
       try {
-        //get title ann
-        const titleAnnResponse = await axiosClient.get(
-          `${process.env.ARCORE_SERVER_URL}/api/documents/${manuscriptId}/titleann`,
-          {
-            headers: {
-              [DATAVERSE_HEADER_NAME]: dataverseApiToken,
-              [REQUEST_DESC_HEADER_NAME]: `Getting title annotation from source manuscript ${manuscriptId}`,
+        const [titleAnnResponse, myDataResponse] = await Promise.all([
+          axiosClient.get(
+            `${process.env.ARCORE_SERVER_URL}/api/documents/${manuscriptId}/titleann`,
+            {
+              headers: {
+                [DATAVERSE_HEADER_NAME]: dataverseApiToken,
+                [REQUEST_DESC_HEADER_NAME]: `Getting title annotation from source manuscript ${manuscriptId}`,
+              },
+            }
+          ),
+          axiosClient.get(`${process.env.DATAVERSE_SERVER_URL}/api/mydata/retrieve`, {
+            params: {
+              key: dataverseApiToken,
+              dvobject_types: DATASET_DV_TYPE,
+              published_states: PUBLICATION_STATUSES,
+              mydata_search_term: `"${datasetDoi}"`,
             },
-          }
-        )
-        //send title ann
+            paramsSerializer: (params) => {
+              return qs.stringify(params, { indices: false })
+            },
+            headers: {
+              [REQUEST_DESC_HEADER_NAME]: `Searching for data project ${datasetDoi}`,
+            },
+          }),
+        ])
+
+        if (!myDataResponse.data.success || myDataResponse.data.data.items.length === 0) {
+          res.status(400).json({ message: "Unable to find data project to get citation." })
+        }
+        const dataset = myDataResponse.data.data.items[0]
+        const citationHtml = dataset.citationHtml
+        const doiUrl = dataset.url
+
         const annotation = titleAnnResponse.data
         annotation.target.forEach((element: any) => {
           element.source = destinationUrl
@@ -41,12 +74,9 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
           JSON.stringify({
             uri: destinationUrl,
             document: annotation.document,
-            //assume text already has the QDR header
-            text: annotation.text,
-            //tags: annotation.tags,
+            text: createInitialAnnotationText(citationHtml, doiUrl),
             target: annotation.target,
             group: destinationHypothesisGroup,
-            //TODO: need to test
             permissions: { read: newReadPermission },
           }),
           {
@@ -57,7 +87,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
             },
           }
         )
-        res.status(200)
+        res.status(200).json({ message: "Added ATI annotation to title." })
       } catch (e) {
         const { status, message } = getResponseFromError(e, requestDesc)
         console.error(status, message)

--- a/pages/ati/[id]/exportAnnotations.tsx
+++ b/pages/ati/[id]/exportAnnotations.tsx
@@ -29,9 +29,16 @@ interface AtiPageProps {
   serverUrl: string
   atiProjectDetails: IATIProjectDetails | null
   hypothesisGroups: IHypothesisGroup[]
+  isAdminUser: boolean
 }
 
-const AtiPage: FC<AtiPageProps> = ({ user, atiProjectDetails, hypothesisGroups, appUrl }) => {
+const AtiPage: FC<AtiPageProps> = ({
+  user,
+  atiProjectDetails,
+  hypothesisGroups,
+  appUrl,
+  isAdminUser,
+}) => {
   return (
     <AtiTab
       user={user}
@@ -44,6 +51,7 @@ const AtiPage: FC<AtiPageProps> = ({ user, atiProjectDetails, hypothesisGroups, 
           datasetId={atiProjectDetails.dataset.id}
           manuscript={atiProjectDetails.manuscript}
           hypothesisGroups={hypothesisGroups}
+          canAddQdrInfo={isAdminUser}
         />
       )}
     </AtiTab>
@@ -60,6 +68,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
     appUrl: process.env.NEXTAUTH_URL as string,
     serverUrl: process.env.DATAVERSE_SERVER_URL as string,
     hypothesisGroups: [],
+    isAdminUser: false,
   }
   const datasetId = context?.params?.id
 
@@ -69,6 +78,9 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
 
   if (session) {
     const { dataverseApiToken, hypothesisApiToken } = session
+    if (hypothesisApiToken === process.env.ADMIN_HYPOTHESIS_API_TOKEN) {
+      props.isAdminUser = true
+    }
     //Get the dataset json
     await axiosClient
       .get(`${process.env.DATAVERSE_SERVER_URL}/api/datasets/${datasetId}`, {

--- a/pages/ati/[id]/exportAnnotations.tsx
+++ b/pages/ati/[id]/exportAnnotations.tsx
@@ -48,7 +48,7 @@ const AtiPage: FC<AtiPageProps> = ({
       {atiProjectDetails && (
         <AtiExportAnnotations
           appUrl={appUrl}
-          datasetId={atiProjectDetails.dataset.id}
+          dataset={atiProjectDetails.dataset}
           manuscript={atiProjectDetails.manuscript}
           hypothesisGroups={hypothesisGroups}
           canAddQdrInfo={isAdminUser}

--- a/utils/hypothesisUtils.ts
+++ b/utils/hypothesisUtils.ts
@@ -176,16 +176,22 @@ export async function exportAnnotations(args: ExportAnnotationsArgs): Promise<nu
   return totalExported
 }
 
-export function createInitialAnnotationText(citation: string, doi: string): string {
-  //const nonVersionedCitation = citation.split(". ")
-  //nonVersionedCitation.pop()
+export function createInitialAnnotationText(
+  citation: string,
+  doi: string,
+  isDraftState: boolean
+): string {
+  const citationArr = citation.split(". ")
+  if (isDraftState) {
+    citationArr.pop()
+  }
   return `${ATI_HEADER_HTML}This is an Annotation for Transparent Inquiry project, published by the <a href="https://qdr.syr.edu">Qualitative Data Repository</a>.
 
   <b>The <a href="${doi}">Data Overview</a> discusses project context, data generation and analysis, and logic of annotation.</b>
   
   Please cite as:
 
-  ${citation}
+  ${citationArr.join(". ")}${isDraftState ? "." : ""}
 
   <a href="https://qdr.syr.edu/ati">Learn more about ATI here</a>.`
 }

--- a/utils/hypothesisUtils.ts
+++ b/utils/hypothesisUtils.ts
@@ -161,5 +161,13 @@ export async function exportAnnotations(args: ExportAnnotationsArgs): Promise<nu
     totalExported += response.data.total
   }
   //TODO: write one intial annotation on the title
+  if (addQdrInfo /**manuscriptId */) {
+    await axiosClient.post(`/api/hypothesis/${datasetId}/title-annotation`, {
+      destinationUrl,
+      destinationHypothesisGroup,
+      privateAnnotation,
+      //manuscriptId
+    })
+  }
   return totalExported
 }

--- a/utils/hypothesisUtils.ts
+++ b/utils/hypothesisUtils.ts
@@ -109,6 +109,7 @@ interface ExportAnnotationsArgs {
   destinationHypothesisGroup: string
   privateAnnotation: boolean
   isAdminAuthor: boolean
+  addQdrInfo: boolean
   taskDispatch: Dispatch<ITaskAction>
 }
 export async function exportAnnotations(args: ExportAnnotationsArgs): Promise<number> {
@@ -120,6 +121,7 @@ export async function exportAnnotations(args: ExportAnnotationsArgs): Promise<nu
     destinationHypothesisGroup,
     privateAnnotation,
     isAdminAuthor,
+    addQdrInfo,
     taskDispatch,
   } = args
   const total = await getTotalAnnotations({
@@ -127,7 +129,7 @@ export async function exportAnnotations(args: ExportAnnotationsArgs): Promise<nu
     isAdminDownloader,
     hypothesisGroup: sourceHypothesisGroup,
   })
-  let totalDeleted = 0
+  let totalExported = 0
   const offsets = range(0, total - 1, REQUEST_BATCH_SIZE)
   for (const offset of offsets) {
     taskDispatch({
@@ -147,6 +149,7 @@ export async function exportAnnotations(args: ExportAnnotationsArgs): Promise<nu
         destinationHypothesisGroup,
         isAdminAuthor,
         privateAnnotation,
+        addQdrInfo,
         limit: REQUEST_BATCH_SIZE,
       }),
       {
@@ -155,7 +158,8 @@ export async function exportAnnotations(args: ExportAnnotationsArgs): Promise<nu
         },
       }
     )
-    totalDeleted += response.data.total
+    totalExported += response.data.total
   }
-  return totalDeleted
+  //TODO: write one intial annotation on the title
+  return totalExported
 }


### PR DESCRIPTION
When exporting annotations, allow an admin of AnnoRep to add an ATI header to all annotations, and an initial annotation anchored to the title of the manuscript.