### PR TITLE
feature/restrict-visible-data-projects-on-home-page

### DIFF
--- a/constants/dataverse.ts
+++ b/constants/dataverse.ts
@@ -39,3 +39,9 @@ export const PUBLICATION_STATUSES_COLOR: Record<string, TagTypeName> = {
 export const DATASET_DV_TYPE = "Dataset"
 
 export const PUBLICATION_STATUS_NAME = "Publication Statuses"
+
+export const ROLE_IDS = [
+  1, // admin
+  6, // contributor
+  7, // curator
+]

--- a/pages/api/mydata-search.ts
+++ b/pages/api/mydata-search.ts
@@ -8,6 +8,7 @@ import {
   ANNOREP_METADATA_VALUE,
   DATASET_DV_TYPE,
   KIND_OF_DATA_NAME,
+  ROLE_IDS,
 } from "../../constants/dataverse"
 import { REQUEST_DESC_HEADER_NAME } from "../../constants/http"
 import { IAtiProject } from "../../types/ati"
@@ -37,6 +38,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
               published_states: publicationStatuses,
               mydata_search_term: searchTerm,
               selected_page: selectedPage || 1,
+              role_ids: ROLE_IDS,
             },
             paramsSerializer: (params) => {
               return qs.stringify(params, { indices: false })

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -22,6 +22,7 @@ import {
   DATASET_DV_TYPE,
   KIND_OF_DATA_NAME,
   PUBLICATION_STATUSES,
+  ROLE_IDS,
 } from "../constants/dataverse"
 import { IAnnoRepUser } from "../types/auth"
 import { getAnnoRepUser } from "../utils/authUtils"
@@ -102,6 +103,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
             dvobject_types: DATASET_DV_TYPE,
             published_states: PUBLICATION_STATUSES,
             mydata_search_term: `${KIND_OF_DATA_NAME}:${ANNOREP_METADATA_VALUE}`,
+            role_ids: ROLE_IDS,
           },
           paramsSerializer: (params) => {
             return qs.stringify(params, { indices: false })

--- a/pages/new/index.tsx
+++ b/pages/new/index.tsx
@@ -15,6 +15,7 @@ import {
   DATASET_DV_TYPE,
   KIND_OF_DATA_NAME,
   PUBLICATION_STATUSES,
+  ROLE_IDS,
 } from "../../constants/dataverse"
 import { REQUEST_DESC_HEADER_NAME } from "../../constants/http"
 import { IAnnoRepUser } from "../../types/auth"
@@ -74,6 +75,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
             dvobject_types: DATASET_DV_TYPE,
             published_states: PUBLICATION_STATUSES,
             mydata_search_term: `-${KIND_OF_DATA_NAME}:${ANNOREP_METADATA_VALUE}`,
+            role_ids: ROLE_IDS,
           },
           paramsSerializer: (params) => {
             return qs.stringify(params, { indices: false })


### PR DESCRIPTION
Specify `role_ids` in the dataverse `mydata/retrieve` endpoint. This will limit the visible data projects (on the home page and new ATI page) to those who are either Admin, Curator, or Contributor.