### PR TITLE
fix/orphaned-annotations

### DIFF
--- a/features/ati/AtiManuscript/IngestPdf/index.tsx
+++ b/features/ati/AtiManuscript/IngestPdf/index.tsx
@@ -1,6 +1,7 @@
 import { FC, useState } from "react"
 
 import { InlineNotification } from "carbon-components-react"
+import DOMPurify from "isomorphic-dompurify"
 
 import { Document, Page, pdfjs } from "react-pdf"
 import { SizeMe } from "react-sizeme"
@@ -16,6 +17,17 @@ const IngestPdf: FC<IngestPdfProps> = ({ pdf }) => {
   const [numPages, setNumPages] = useState<number>(0)
 
   const onDocumentLoadSuccess = ({ numPages }: { numPages: number }) => {
+    // load hypothesis client
+    const hClientConfig = document.createElement("script")
+    hClientConfig.type = "application/json"
+    hClientConfig.className = "js-hypothesis-config"
+    hClientConfig.innerHTML = DOMPurify.sanitize(JSON.stringify({ openSidebar: true }))
+    const hClient = document.createElement("script")
+    hClient.src = "https://hypothes.is/embed.js"
+    hClient.async = true
+    document.head.appendChild(hClientConfig)
+    document.head.appendChild(hClient)
+
     setNumPages(numPages)
   }
 

--- a/features/ati/AtiTab/AtiTab.stories.tsx
+++ b/features/ati/AtiTab/AtiTab.stories.tsx
@@ -29,7 +29,6 @@ const args = {
     publicationStatuses: ["Draft"],
     citationHtml: "Citation HTML",
   },
-  hasPdf: false,
 }
 
 export const AtiSummary = Template.bind({})

--- a/features/ati/AtiTab/index.tsx
+++ b/features/ati/AtiTab/index.tsx
@@ -19,12 +19,10 @@ export interface AtiTabProps {
   user: IAnnoRepUser | null
   /** The dataset for the ati project */
   dataset: IDataset | null
-  /** Display Hypothes.is client? */
-  hasPdf?: boolean
 }
 
 /** A container for different tabs of an ati project */
-const AtiTab: FC<AtiTabProps> = ({ dataset, children, user, selectedTab, hasPdf }: AtiTabProps) => {
+const AtiTab: FC<AtiTabProps> = ({ dataset, children, user, selectedTab }: AtiTabProps) => {
   const onSelectionChange = (index: number) =>
     window.location.assign(`/ati/${dataset?.id}/${tabs[index]}`)
   const selectedTabIndex = tabs.findIndex((tab) => tab === selectedTab)
@@ -70,7 +68,7 @@ const AtiTab: FC<AtiTabProps> = ({ dataset, children, user, selectedTab, hasPdf 
     )
   }
   return (
-    <Layout title={dataset ? `AnnoREP - ${dataset.title}` : "AnnoREP"} user={user} hasPdf={hasPdf}>
+    <Layout title={dataset ? `AnnoREP - ${dataset.title}` : "AnnoREP"} user={user}>
       {content}
     </Layout>
   )

--- a/features/components/Layout/index.tsx
+++ b/features/components/Layout/index.tsx
@@ -1,6 +1,5 @@
-import { ReactNode, FC, useEffect } from "react"
+import { ReactNode, FC } from "react"
 
-import DOMPurify from "isomorphic-dompurify"
 import Head from "next/head"
 
 import AppBar from "../AppBar"
@@ -14,24 +13,9 @@ interface LayoutProps {
   children: ReactNode
   user: IAnnoRepUser | null
   isFullWidth?: boolean
-  hasPdf?: boolean
 }
 
-const Layout: FC<LayoutProps> = ({ title, children, user, isFullWidth, hasPdf }) => {
-  useEffect(() => {
-    if (hasPdf) {
-      const hClientConfig = document.createElement("script")
-      hClientConfig.type = "application/json"
-      hClientConfig.className = "js-hypothesis-config"
-      hClientConfig.innerHTML = DOMPurify.sanitize(JSON.stringify({ openSidebar: true }))
-      const hClient = document.createElement("script")
-      hClient.src = "https://hypothes.is/embed.js"
-      hClient.async = true
-      document.head.appendChild(hClientConfig)
-      document.head.appendChild(hClient)
-    }
-  }, [hasPdf])
-
+const Layout: FC<LayoutProps> = ({ title, children, user, isFullWidth }) => {
   return (
     <>
       <Head>

--- a/pages/ati/[id]/manuscript.tsx
+++ b/pages/ati/[id]/manuscript.tsx
@@ -34,7 +34,6 @@ const AtiPage: FC<AtiPageProps> = ({ user, serverUrl, atiProjectDetails }) => {
       user={user}
       dataset={atiProjectDetails ? atiProjectDetails.dataset : null}
       selectedTab={AtiTabConstant.manuscript.id}
-      hasPdf={atiProjectDetails?.manuscript.id ? true : false}
     >
       {atiProjectDetails && (
         <AtiManuscript


### PR DESCRIPTION
**Pull request recommendations:**

- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [x] Link to any relevant issue in the PR description. Ex: _Resolves [gh-12], adds tiff file format support_
- #45 
- [x] Provide context of changes.
- Did some testing and the hypothesis client is sometimes loaded before the ingest PDF is loaded, leading to orphaned annotations.
- The previous fix #51 loads the hypothesis client after the manuscript page has loaded. Which doesn't necessarily mean that the ingest PDF has loaded. This PR loads the hypothesis client after the ingest PDF has loaded.
- [ ] Provide relevant tests for your feature or bug fix.
- [ ] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
