### PR TITLE
admin/upgrade-axios-0.28.0

### DIFF
--- a/features/app/index.ts
+++ b/features/app/index.ts
@@ -10,9 +10,18 @@ axiosRetry(axiosClient, {
     if (error.response) {
       const retryAfter = error.response.headers["retry-after"]
       if (retryAfter) {
-        return retryAfter
+        const retryAfterSeconds = parseInt(retryAfter.trim(), 10)
+        if (!isNaN(retryAfterSeconds)) {
+          return retryAfterSeconds
+        }
+        const retryAfterDate = Date.parse(retryAfter.trim())
+        if (!isNaN(retryAfterDate)) {
+          const currentTime = Date.now()
+          const delay = Math.max(retryAfterDate - currentTime, 0)
+          return delay
+        }
       }
-      if (error.response.status === 429 && error.config.url?.includes(HYPOTHESIS_API_BASE_URL)) {
+      if (error.response.status === 429 && error.config?.url?.includes(HYPOTHESIS_API_BASE_URL)) {
         return retryCount * 2000 /** ms */
       }
     }

--- a/features/app/index.ts
+++ b/features/app/index.ts
@@ -12,7 +12,7 @@ axiosRetry(axiosClient, {
       if (retryAfter) {
         const retryAfterSeconds = parseInt(retryAfter.trim(), 10)
         if (!isNaN(retryAfterSeconds)) {
-          return retryAfterSeconds
+          return retryAfterSeconds * 1000
         }
         const retryAfterDate = Date.parse(retryAfter.trim())
         if (!isNaN(retryAfterDate)) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10515,11 +10515,13 @@
       "dev": true
     },
     "axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.28.0.tgz",
+      "integrity": "sha512-Tu7NYoGY4Yoc7I+Npf9HhUMtEEpV7ZiLH9yndTCoNhcpBH0kwcvFbzYN9/u5QKI5A6uefjsNNWaz5olJVYS62Q==",
       "requires": {
-        "follow-redirects": "^1.14.0"
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "axios-retry": {
@@ -21759,6 +21761,11 @@
         "forwarded": "0.2.0",
         "ipaddr.js": "1.9.1"
       }
+    },
+    "proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "prr": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@prisma/client": "^2.27.0",
     "@types/carbon-components-react": "^7.44.0",
     "@types/carbon__icons-react": "^10.31.2",
-    "axios": "^0.21.4",
+    "axios": "^0.28.0",
     "axios-retry": "^3.2.4",
     "carbon-components": "^10.45.0",
     "carbon-components-react": "^7.45.0",

--- a/pages/api/arcore/[id]/index.ts
+++ b/pages/api/arcore/[id]/index.ts
@@ -20,7 +20,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       try {
         await axiosClient.put(`${process.env.ARCORE_SERVER_URL}/api/documents/${id}`, undefined, {
           headers: {
-            [DATAVERSE_HEADER_NAME]: dataverseApiToken,
+            [DATAVERSE_HEADER_NAME]: dataverseApiToken as string,
             [REQUEST_DESC_HEADER_NAME]: `Creating ingest PDF and extracting annotations from source manuscript ${id}`,
           },
         })
@@ -29,7 +29,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
             `${process.env.ARCORE_SERVER_URL}/api/documents/${id}/ann`,
             {
               headers: {
-                [DATAVERSE_HEADER_NAME]: dataverseApiToken,
+                [DATAVERSE_HEADER_NAME]: dataverseApiToken as string,
                 [REQUEST_DESC_HEADER_NAME]: `Getting annotations from source manuscript ${id}`,
               },
             }

--- a/pages/api/datasets/[id]/annorep/delete.ts
+++ b/pages/api/datasets/[id]/annorep/delete.ts
@@ -26,7 +26,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
           },
           headers: {
             "Content-Type": "application/json-ld", //TODO: change ld+json?
-            [DATAVERSE_HEADER_NAME]: session.dataverseApiToken,
+            [DATAVERSE_HEADER_NAME]: session.dataverseApiToken as string,
             [REQUEST_DESC_HEADER_NAME]: requestDesc,
           },
         })

--- a/pages/api/datasets/[id]/annorep/index.ts
+++ b/pages/api/datasets/[id]/annorep/index.ts
@@ -29,7 +29,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
           },
           headers: {
             "Content-Type": "application/json-ld", //TODO: change ld+json?
-            [DATAVERSE_HEADER_NAME]: session.dataverseApiToken,
+            [DATAVERSE_HEADER_NAME]: session.dataverseApiToken as string,
             [REQUEST_DESC_HEADER_NAME]: requestDesc,
           },
         })

--- a/pages/api/datasets/[id]/data-files.ts
+++ b/pages/api/datasets/[id]/data-files.ts
@@ -18,7 +18,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
           method: "GET",
           url: `${process.env.DATAVERSE_SERVER_URL}/api/datasets/${id}`,
           headers: {
-            [DATAVERSE_HEADER_NAME]: session.dataverseApiToken,
+            [DATAVERSE_HEADER_NAME]: session.dataverseApiToken as string,
             [REQUEST_DESC_HEADER_NAME]: requestDesc,
           },
         })

--- a/pages/api/datasets/[id]/manuscript/index.ts
+++ b/pages/api/datasets/[id]/manuscript/index.ts
@@ -59,7 +59,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
               data: addManuscriptForm,
               headers: {
                 "Content-Type": `${addManuscriptForm.getHeaders()["content-type"]}`,
-                [DATAVERSE_HEADER_NAME]: dataverseApiToken,
+                [DATAVERSE_HEADER_NAME]: dataverseApiToken as string,
                 [REQUEST_DESC_HEADER_NAME]: requestDesc,
               },
             })

--- a/pages/api/datasets/[id]/submit-for-review.ts
+++ b/pages/api/datasets/[id]/submit-for-review.ts
@@ -18,7 +18,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
           method: "POST",
           url: `${process.env.DATAVERSE_SERVER_URL}/api/datasets/${id}/submitForReview`,
           headers: {
-            [DATAVERSE_HEADER_NAME]: session.dataverseApiToken,
+            [DATAVERSE_HEADER_NAME]: session.dataverseApiToken as string,
             [REQUEST_DESC_HEADER_NAME]: requestDesc,
           },
         })

--- a/pages/api/hypothesis/[id]/title-annotation.ts
+++ b/pages/api/hypothesis/[id]/title-annotation.ts
@@ -33,7 +33,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
             `${process.env.ARCORE_SERVER_URL}/api/documents/${manuscriptId}/titleann`,
             {
               headers: {
-                [DATAVERSE_HEADER_NAME]: dataverseApiToken,
+                [DATAVERSE_HEADER_NAME]: dataverseApiToken as string,
                 [REQUEST_DESC_HEADER_NAME]: `Getting title annotation from source manuscript ${manuscriptId}`,
                 Accept: "application/json",
               },

--- a/pages/ati/[id]/exportAnnotations.tsx
+++ b/pages/ati/[id]/exportAnnotations.tsx
@@ -86,7 +86,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
     await axiosClient
       .get(`${process.env.DATAVERSE_SERVER_URL}/api/datasets/${datasetId}`, {
         headers: {
-          [DATAVERSE_HEADER_NAME]: dataverseApiToken,
+          [DATAVERSE_HEADER_NAME]: dataverseApiToken as string,
           [REQUEST_DESC_HEADER_NAME]: `Getting JSON for data project ${datasetId}`,
           Accept: "application/json",
         },
@@ -108,7 +108,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
             {
               responseType: "arraybuffer",
               headers: {
-                [DATAVERSE_HEADER_NAME]: dataverseApiToken,
+                [DATAVERSE_HEADER_NAME]: dataverseApiToken as string,
                 Accept: "application/pdf",
               },
             }

--- a/pages/ati/[id]/manuscript.tsx
+++ b/pages/ati/[id]/manuscript.tsx
@@ -68,7 +68,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
     await axiosClient
       .get(`${process.env.DATAVERSE_SERVER_URL}/api/datasets/${datasetId}`, {
         headers: {
-          [DATAVERSE_HEADER_NAME]: dataverseApiToken,
+          [DATAVERSE_HEADER_NAME]: dataverseApiToken as string,
           [REQUEST_DESC_HEADER_NAME]: `Getting JSON for data project ${datasetId}`,
           Accept: "application/json",
         },
@@ -89,7 +89,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
             {
               responseType: "arraybuffer",
               headers: {
-                [DATAVERSE_HEADER_NAME]: dataverseApiToken,
+                [DATAVERSE_HEADER_NAME]: dataverseApiToken as string,
                 Accept: "application/pdf",
               },
             }

--- a/pages/ati/[id]/settings.tsx
+++ b/pages/ati/[id]/settings.tsx
@@ -58,7 +58,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
     await axios
       .get(`${process.env.DATAVERSE_SERVER_URL}/api/datasets/${datasetId}`, {
         headers: {
-          [DATAVERSE_HEADER_NAME]: dataverseApiToken,
+          [DATAVERSE_HEADER_NAME]: dataverseApiToken as string,
           [REQUEST_DESC_HEADER_NAME]: `Getting JSON for data project ${datasetId}`,
           Accept: "application/json",
         },

--- a/pages/ati/[id]/summary.tsx
+++ b/pages/ati/[id]/summary.tsx
@@ -79,7 +79,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
     await axiosClient
       .get(`${process.env.DATAVERSE_SERVER_URL}/api/datasets/${datasetId}`, {
         headers: {
-          [DATAVERSE_HEADER_NAME]: dataverseApiToken,
+          [DATAVERSE_HEADER_NAME]: dataverseApiToken as string,
           [REQUEST_DESC_HEADER_NAME]: `Getting JSON for data project ${datasetId}`,
           Accept: "application/json",
         },

--- a/utils/httpRequestUtils.ts
+++ b/utils/httpRequestUtils.ts
@@ -5,10 +5,14 @@ import { AnnoRepResponse } from "../types/http"
 export const getResponseFromError = (e: unknown, requestDesc?: string): AnnoRepResponse => {
   const annoRepResponse: AnnoRepResponse = { status: 400, message: "" }
   if (axios.isAxiosError(e)) {
-    const requestInfo =
-      e.config.headers[REQUEST_DESC_HEADER_NAME] ||
-      requestDesc ||
-      `${e.config.method} ${e.config.url}`
+    let requestInfo = "Request"
+    if (e.config && e.config.headers && e.config.headers[REQUEST_DESC_HEADER_NAME]) {
+      requestInfo = e.config.headers[REQUEST_DESC_HEADER_NAME] as string
+    } else if (requestDesc) {
+      requestInfo = requestDesc
+    } else if (e.config && e.config.method && e.config.url) {
+      requestInfo = `${e.config.method} ${e.config.url}`
+    }
     let failureMessage = `${requestInfo} failed.`
     if (e.response) {
       const additional =


### PR DESCRIPTION
Upgrade to axios-0.28.0 to fix the vulnerability in #162.

This version has better type definitions. Fixed as few cosmetic errors so that the app can build/pass CI. These include:
- better typed retryDelay function that handles if `retry-after` header are present in the response
- better typed getResponseFromError function that uses the AxiosError better



