### PR TITLE
code-quality/Incomplete-URL-substring-sanitization

### DIFF
--- a/features/app/index.ts
+++ b/features/app/index.ts
@@ -1,5 +1,6 @@
 import axios from "axios"
 import axiosRetry from "axios-retry"
+import { isSameHostName } from "../../utils/httpRequestUtils"
 
 const HYPOTHESIS_API_BASE_URL = process.env.HYPOTHESIS_SERVER_URL || "https://api.hypothes.is"
 
@@ -21,16 +22,22 @@ axiosRetry(axiosClient, {
           return delay
         }
       }
-      if (error.response.status === 429 && error.config?.url?.includes(HYPOTHESIS_API_BASE_URL)) {
-        return retryCount * 2000 /** ms */
+      if (error.response.status === 429 && error.config?.url) {
+        const isHypothesisUrl = isSameHostName(error.config.url, HYPOTHESIS_API_BASE_URL)
+        if (isHypothesisUrl) {
+          return retryCount * 2000 /** ms */
+        }
       }
     }
     return axiosRetry.exponentialDelay(retryCount)
   },
   retryCondition: (e) => {
     if (e.response) {
-      if (e.response.status === 429 && e.response.config.url?.includes(HYPOTHESIS_API_BASE_URL)) {
-        return true
+      if (e.response.status === 429 && e.response.config.url) {
+        const isHypothesisUrl = isSameHostName(e.response.config.url, HYPOTHESIS_API_BASE_URL)
+        if (isHypothesisUrl) {
+          return true
+        }
       }
     }
     return axiosRetry.isNetworkOrIdempotentRequestError(e)

--- a/utils/httpRequestUtils.ts
+++ b/utils/httpRequestUtils.ts
@@ -45,3 +45,14 @@ export const getMessageFromError = (e: unknown): string => {
   }
   return msg
 }
+
+export const isSameHostName = (urlStr: string, otherUrlStr: string): boolean => {
+  try {
+    const url = new URL(urlStr)
+    const otherUrl = new URL(otherUrlStr)
+    return url.hostname === otherUrl.hostname
+  } catch (e) {
+    console.warn("Invalid URL:", (e as Error).message)
+    return false
+  }
+}

--- a/utils/httpRequestUtils.ts
+++ b/utils/httpRequestUtils.ts
@@ -52,7 +52,7 @@ export const isSameHostName = (urlStr: string, otherUrlStr: string): boolean => 
     const otherUrl = new URL(otherUrlStr)
     return url.hostname === otherUrl.hostname
   } catch (e) {
-    console.warn("Invalid URL:", (e as Error).message)
+    console.warn("Invalid URL:", getMessageFromError(e))
     return false
   }
 }


### PR DESCRIPTION
See https://github.com/QualitativeDataRepository/AnnoREP-Frontend/security/code-scanning/3 and https://github.com/QualitativeDataRepository/AnnoREP-Frontend/security/code-scanning/2 for context.

In order to check if the retry URL is for the Hypothesis API URL, create URL objects from the two strings and check if the two URLs have the same host-name.
