### PR TITLE
bugfix/search projects

### DIFF
--- a/features/ati/AtiProjects/useSearch.ts
+++ b/features/ati/AtiProjects/useSearch.ts
@@ -33,8 +33,10 @@ const useSearch = (inititalState: ISearchState): [ISearchState, Dispatch<ISearch
             selectedPage: state.fetchPage ? state.page + 1 : 1,
             isAnnoRep: true,
           },
-          paramsSerializer: (params) => {
-            return qs.stringify(params, { indices: false })
+          paramsSerializer: {
+            serialize: (params) => {
+              return qs.stringify(params, { indices: false })
+            },
           },
         })
         if (!didCancel) {

--- a/features/ati/NewAtiProjectForm/useDatasetSearch.ts
+++ b/features/ati/NewAtiProjectForm/useDatasetSearch.ts
@@ -34,8 +34,10 @@ const useSearchDataset = (
             isAnnoRep: false,
             publicationStatuses: PUBLICATION_STATUSES,
           },
-          paramsSerializer: (params) => {
-            return qs.stringify(params, { indices: false })
+          paramsSerializer: {
+            serialize: (params) => {
+              return qs.stringify(params, { indices: false })
+            },
           },
         })
         if (!didCancel) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10515,9 +10515,9 @@
       "dev": true
     },
     "axios": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.28.0.tgz",
-      "integrity": "sha512-Tu7NYoGY4Yoc7I+Npf9HhUMtEEpV7ZiLH9yndTCoNhcpBH0kwcvFbzYN9/u5QKI5A6uefjsNNWaz5olJVYS62Q==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.28.1.tgz",
+      "integrity": "sha512-iUcGA5a7p0mVb4Gm/sy+FSECNkPFT4y7wt6OM/CDpO/OnNCvSs3PoMG8ibrC9jRoGYU0gUK5pXVC4NPXq6lHRQ==",
       "requires": {
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@prisma/client": "^2.27.0",
     "@types/carbon-components-react": "^7.44.0",
     "@types/carbon__icons-react": "^10.31.2",
-    "axios": "^0.28.0",
+    "axios": "^0.28.1",
     "axios-retry": "^3.2.4",
     "carbon-components": "^10.45.0",
     "carbon-components-react": "^7.45.0",

--- a/pages/api/hypothesis/[id]/title-annotation.ts
+++ b/pages/api/hypothesis/[id]/title-annotation.ts
@@ -46,8 +46,10 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
               published_states: PUBLICATION_STATUSES,
               mydata_search_term: `"${datasetDoi}"`,
             },
-            paramsSerializer: (params) => {
-              return qs.stringify(params, { indices: false })
+            paramsSerializer: {
+              serialize: (params) => {
+                return qs.stringify(params, { indices: false })
+              },
             },
             headers: {
               [REQUEST_DESC_HEADER_NAME]: `Searching for data project ${datasetDoi}`,

--- a/pages/api/mydata-search.ts
+++ b/pages/api/mydata-search.ts
@@ -40,8 +40,10 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
               selected_page: selectedPage || 1,
               role_ids: ROLE_IDS,
             },
-            paramsSerializer: (params) => {
-              return qs.stringify(params, { indices: false })
+            paramsSerializer: {
+              serialize: (params) => {
+                return qs.stringify(params, { indices: false })
+              },
             },
             headers: {
               [REQUEST_DESC_HEADER_NAME]: `Searching for ${

--- a/pages/ati/[id]/summary.tsx
+++ b/pages/ati/[id]/summary.tsx
@@ -94,8 +94,10 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
             published_states: PUBLICATION_STATUSES,
             mydata_search_term: `"${dsPersistentId}"`,
           },
-          paramsSerializer: (params) => {
-            return qs.stringify(params, { indices: false })
+          paramsSerializer: {
+            serialize: (params) => {
+              return qs.stringify(params, { indices: false })
+            },
           },
           headers: {
             [REQUEST_DESC_HEADER_NAME]: `Searching for data project ${dsPersistentId}`,

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -105,8 +105,10 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
             mydata_search_term: `${KIND_OF_DATA_NAME}:${ANNOREP_METADATA_VALUE}`,
             role_ids: ROLE_IDS,
           },
-          paramsSerializer: (params) => {
-            return qs.stringify(params, { indices: false })
+          paramsSerializer: {
+            serialize: (params) => {
+              return qs.stringify(params, { indices: false })
+            },
           },
           headers: {
             [REQUEST_DESC_HEADER_NAME]: `Searching for ${ANNOREP_METADATA_VALUE} data projects`,

--- a/pages/new/index.tsx
+++ b/pages/new/index.tsx
@@ -77,8 +77,10 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
             mydata_search_term: `-${KIND_OF_DATA_NAME}:${ANNOREP_METADATA_VALUE}`,
             role_ids: ROLE_IDS,
           },
-          paramsSerializer: (params) => {
-            return qs.stringify(params, { indices: false })
+          paramsSerializer: {
+            serialize: (params) => {
+              return qs.stringify(params, { indices: false })
+            },
           },
           headers: {
             [REQUEST_DESC_HEADER_NAME]: `Searching for non ${ANNOREP_METADATA_VALUE} data projects`,


### PR DESCRIPTION
Resolves #176 

- Upgrade axios to 0.28.1.

- Although the new type definition supports `paramsSerializer` as a custom function, the code doesn't actually support it.  Changed the `paramsSerializer` config into a object where it has a `serialize` function.
